### PR TITLE
Fix dynamic test

### DIFF
--- a/Akavache.Tests/BlobCacheExtensionsFixture.cs
+++ b/Akavache.Tests/BlobCacheExtensionsFixture.cs
@@ -75,9 +75,9 @@ namespace Akavache.Tests
 
                 Thread.Sleep(500);
 
-                dynamic result = fixture.GetObjectAsync<dynamic>("foo", true, typeof(Tuple<string, string>));
-                Assert.Equal("bar", result.Item1);
-                Assert.Equal("baz", result.Item2);
+                dynamic result = fixture.GetObjectAsync<dynamic>("foo", false, typeof(Tuple<string, string>)).First();
+                Assert.Equal("bar", (string)result.Item1);
+                Assert.Equal("baz", (string)result.Item2);
             }
         }
 

--- a/Akavache/BlobCacheExtensions.cs
+++ b/Akavache/BlobCacheExtensions.cs
@@ -42,15 +42,11 @@ namespace Akavache
         /// <returns>A Future result representing the object in the cache.</returns>
         public static IObservable<T> GetObjectAsync<T>(this IBlobCache This, string key, bool noTypePrefix = false, Type prefixedType = null)
         {
-            if (typeof(T) == typeof(object))
-            {
-                return (IObservable<T>)This.GetAsync(noTypePrefix ? key : GetTypePrefixedKey(key, typeof(T)))
-                    .SelectMany(DeserializeDynamic);
-            }
-
             var type = prefixedType ?? typeof(T);
-            return This.GetAsync(noTypePrefix ? key : GetTypePrefixedKey(key, type))
-                .SelectMany(DeserializeObject<T>);
+            var prefixedKey = noTypePrefix ? key : GetTypePrefixedKey(key, type);
+
+            return This.GetAsync(prefixedKey)
+                .SelectMany(bytes => typeof(T) == typeof(object) ? (IObservable<T>)DeserializeDynamic(bytes) : DeserializeObject<T>(bytes));
         }
 
         /// <summary>


### PR DESCRIPTION
There were three bugs here:
1. `GetObjectAsync` was ignoring the `prefixedType` parameter when
   retrieving objects as dynamic.
2. The test was telling `GetObjectAsync` to ignore the `prefixedType` it
   was passing to it.
3. `Assert.Equal` needed some help to know that it was comparing two
   strings.
