### PR TITLE
Made the login method return an actual type

### DIFF
--- a/Akavache.Tests/EncryptedBlobCacheFixture.cs
+++ b/Akavache.Tests/EncryptedBlobCacheFixture.cs
@@ -64,8 +64,8 @@ namespace Akavache.Tests
                 using (var fixture = new TEncryptedBlobCache(path))
                 {
                     var loginInfo = fixture.GetLoginAsync().First();
-                    Assert.Equal(secretUser, loginInfo.Item1);
-                    Assert.Equal(secretPass, loginInfo.Item2);
+                    Assert.Equal(secretUser, loginInfo.UserName);
+                    Assert.Equal(secretPass, loginInfo.Password);
                 }
             }
         }

--- a/Akavache/Akavache.csproj
+++ b/Akavache/Akavache.csproj
@@ -57,6 +57,7 @@
     <Compile Include="DataProtectionApi.cs" />
     <Compile Include="EncryptedBlobCache.cs" />
     <Compile Include="IBlobCache.cs" />
+    <Compile Include="LoginInfo.cs" />
     <Compile Include="PersistentBlobCache.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SimpleFilesystemProvider.cs" />

--- a/Akavache/BlobCacheExtensions.cs
+++ b/Akavache/BlobCacheExtensions.cs
@@ -296,9 +296,9 @@ namespace Akavache
         /// OnError's with KeyNotFoundException.
         /// </summary>
         /// <returns>A Future result representing the user/password Tuple.</returns>
-        public static IObservable<Tuple<string, string>> GetLoginAsync(this ISecureBlobCache This)
+        public static IObservable<LoginInfo> GetLoginAsync(this ISecureBlobCache This)
         {
-            return This.GetObjectAsync<Tuple<string, string>>("login");
+            return This.GetObjectAsync<Tuple<string, string>>("login").Select(info => new LoginInfo(info));
         }
     }
 

--- a/Akavache/LoginInfo.cs
+++ b/Akavache/LoginInfo.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Akavache
+{
+    public class LoginInfo
+    {
+        public LoginInfo(string username, string password)
+        {
+            UserName = username;
+            Password = password;
+        }
+
+        internal LoginInfo(Tuple<string, string> usernameAndLogin) : this(usernameAndLogin.Item2, usernameAndLogin.Item2)
+        {
+        }
+
+        public string UserName { get; private set; }
+        public string Password { get; private set; }
+    }
+}


### PR DESCRIPTION
Every time I use the login api or review code using it, I forget what `Item1` and `Item2` are supposed to be. I think it'd be useful to have this API return something more descriptive.
