### PR TITLE
Added a default constructor and cleaned up others

### DIFF
--- a/Akavache/TestBlobCache.cs
+++ b/Akavache/TestBlobCache.cs
@@ -12,12 +12,19 @@ namespace Akavache
 {
     public class TestBlobCache : ISecureBlobCache
     {
-        public TestBlobCache(IScheduler scheduler = null, params KeyValuePair<string, byte[]>[] initialContents) :
-            this(scheduler, (IEnumerable<KeyValuePair<string, byte[]>>)initialContents)
+        public TestBlobCache() : this(null, null)
         {
         }
 
-        public TestBlobCache(IScheduler scheduler = null, IEnumerable<KeyValuePair<string, byte[]>> initialContents = null)
+        public TestBlobCache(IScheduler scheduler) : this(scheduler, null)
+        {
+        }
+
+        public TestBlobCache(IEnumerable<KeyValuePair<string, byte[]>> initialContents) : this(null, initialContents)
+        {
+        }
+
+        public TestBlobCache(IScheduler scheduler, IEnumerable<KeyValuePair<string, byte[]>> initialContents)
         {
             Scheduler = scheduler ?? System.Reactive.Concurrency.Scheduler.CurrentThread;
             foreach (var item in initialContents ?? Enumerable.Empty<KeyValuePair<string, byte[]>>())
@@ -26,7 +33,9 @@ namespace Akavache
             }
         }
 
-        internal TestBlobCache(Action disposer, IScheduler scheduler = null, IEnumerable<KeyValuePair<string, byte[]>> initialContents = null)
+        internal TestBlobCache(Action disposer, 
+            IScheduler scheduler, 
+            IEnumerable<KeyValuePair<string, byte[]>> initialContents)
             : this(scheduler, initialContents)
         {
             inner = Disposable.Create(disposer);


### PR DESCRIPTION
I meant to do this in a new branch. Whoops! :sunglasses: 

So I finally got fed up with having to do this to create a new test cache. 

```
new TestBlobCache(null, null);
```

The reason is of course the other `ctors` abuse optional parameters so doing this `new TestBlobCache()` as any sane person would want to is ambiguous.

So with these changes, you can use all of the following to create a test blob cache.

```
new TestBlobCache();
new TestBlobCache(RxApp.DeferredScheduler);
new TestBlobCache(RxApp.DeferredScheduler, new Dictionary<string, byte[]>());
new TestBlobCache(new Dictionary<string, byte[]>());
```

I also removed the one with `params` because to call that overload requires some godawful syntax.

```
new TestBlobCache(
    new KeyValuePair<string, byte[]>("pair1", new byte[] {}),
    new KeyValuePair<string, byte[]>("pair2", new byte[] {}));
```

I'm happy to put it back if you feel it's warranted. :hear_no_evil: 

:dancer:
