### PR TITLE
Add a single entry gate for dispose

### DIFF
--- a/Akavache.Tests/BlobCacheFixture.cs
+++ b/Akavache.Tests/BlobCacheFixture.cs
@@ -236,6 +236,14 @@ namespace Akavache.Tests
         }
 
         [Fact]
+        public void ExtraCallsToDisposeDoNothing()
+        {
+            var cache = CreateBlobCache("somepath");
+            cache.Dispose();
+            cache.Dispose();
+        }
+
+        [Fact]
         public void InvalidateAllReallyDoesInvalidateEverything()
         {
             string path;

--- a/Akavache/Akavache.csproj
+++ b/Akavache/Akavache.csproj
@@ -100,6 +100,7 @@
     <Compile Include="PersistentBlobCache.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SimpleFilesystemProvider.cs" />
+    <Compile Include="SingleEntryGate.cs" />
     <Compile Include="StreamMixins.cs" />
     <Compile Include="TestBlobCache.cs" />
     <Compile Include="Utility.cs" />

--- a/Akavache/EncryptedBlobCache.cs
+++ b/Akavache/EncryptedBlobCache.cs
@@ -29,7 +29,7 @@ namespace Akavache
 #endif
         }
 
-        protected override IObservable<byte[]> BeforeWriteToDiskFilter(byte[] data, IScheduler scheduler)
+        protected override IObservable<byte[]> BeforeWriteToDiskFilter(byte[] data, IScheduler scheduler, bool disposing = false)
         {
             try
             {

--- a/Akavache/SingleEntryGate.cs
+++ b/Akavache/SingleEntryGate.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading;
+
+namespace Akavache
+{
+    public class SingleEntryGate
+    {
+        int enterCount;
+
+        /// <summary>
+        /// Returns true for the first and only entry. After that, it returns false.
+        /// </summary>
+        /// <returns></returns>
+        public bool Enter()
+        {
+            IsClosed = true;
+            return Interlocked.Increment(ref enterCount) == 1;
+        }
+
+        public bool IsClosed  { get; private set; }
+    }
+}


### PR DESCRIPTION
This ensures we only call dispose once and that anything other method throws an `ObjectDisposedMethod` when the cache is disposed.

Handling this is trickier than expected. For example, we can't just move `isdisposed` up higher because the `Dispose` method calls other methods that check `isdisposed`. I tried passing in a `disposing`.

Another option is to take the guts of these methods, put them in private methods, and call the same methods from `Dispose` and from the public methods.

I couldn't get all the tests to pass in any situation. :( It would be nice to have more complete test coverage here.
