### PR TITLE
Fix unit test project build

### DIFF
--- a/Akavache.Tests/Akavache.Tests.csproj
+++ b/Akavache.Tests/Akavache.Tests.csproj
@@ -48,6 +48,7 @@
     </Reference>
     <Reference Include="ReactiveUI.Blend">
       <HintPath>..\packages\reactiveui-xaml.4.4.1\lib\Net40\ReactiveUI.Blend.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="ReactiveUI.Routing">
       <HintPath>..\packages\reactiveui-xaml.4.4.1\lib\Net40\ReactiveUI.Routing.dll</HintPath>

--- a/Akavache.Tests/packages.config
+++ b/Akavache.Tests/packages.config
@@ -6,6 +6,7 @@
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
   <package id="reactiveui-core" version="4.4.1" targetFramework="net40" />
   <package id="reactiveui-testing" version="4.4.1" targetFramework="net40" />
+  <package id="reactiveui-xaml" version="4.4.1" targetFramework="net40" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net40" />


### PR DESCRIPTION
packages.config appeared to be missing the reactiveui-xaml package.
Adding this causes it to build.

Note there's one breaking unit test on my machine that's unrelated to this. It's in the SqlLite cache.
