### PR TITLE
Fix race condition reading/writing cache entries

### DIFF
--- a/Akavache.Tests/Akavache.Tests.csproj
+++ b/Akavache.Tests/Akavache.Tests.csproj
@@ -105,6 +105,7 @@
     <Compile Include="BlobCacheFixture.cs" />
     <Compile Include="EncryptedBlobCacheFixture.cs" />
     <Compile Include="PersistentBlobCacheTests.cs" />
+    <Compile Include="Stresser.cs" />
     <Compile Include="Utility.cs" />
     <Compile Include="UtilityTests.cs" />
   </ItemGroup>

--- a/Akavache.Tests/Stresser.cs
+++ b/Akavache.Tests/Stresser.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Akavache.Tests
+{
+    /// <summary>
+    /// Used for various tests that stress Akavache
+    /// </summary>
+    internal class Stresser
+    {
+        static readonly Random random = new Random(DateTime.UtcNow.Millisecond);
+        readonly List<Task> tasks = new List<Task>();
+        readonly ConcurrentBag<Exception> exceptions = new ConcurrentBag<Exception>();
+        bool isRunning;
+
+        public Stresser(IEnumerable<Action<string>> actions)
+        {
+            var key = Guid.NewGuid().ToString();
+            tasks = (from action in actions
+                select new Task(() => RunAction(key, action)))
+                .ToList();
+        }
+
+        public ConcurrentBag<Exception> RunActions(TimeSpan timeout)
+        {
+            isRunning = true;
+            tasks.ForEach(t => t.Start());
+            var timeoutDate = DateTime.UtcNow.Add(timeout);
+
+            while (isRunning && DateTime.UtcNow <= timeoutDate)
+            {
+                Thread.Sleep(0);
+            }
+            isRunning = false;
+            //tasks.ForEach(t => t.Join());
+            Task.WaitAll(tasks.ToArray());
+            tasks.Clear();
+            return exceptions;
+        }
+
+        public static byte[] RandomData()
+        {
+            return Enumerable.Range(0, 10).SelectMany(_ => BitConverter.GetBytes(random.Next())).ToArray();
+        }
+
+        void RunAction(string key, Action<string> action)
+        {
+            try
+            {
+                while (isRunning)
+                {
+                    try
+                    {
+                        action(key);
+                    }
+                    catch (KeyNotFoundException)
+                    {
+                        // continue. This is to be expected.
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                isRunning = false;
+                exceptions.Add(e);
+            }
+        }
+    }
+}

--- a/Akavache/EncryptedBlobCache.cs
+++ b/Akavache/EncryptedBlobCache.cs
@@ -44,11 +44,6 @@ namespace Akavache
 #else
                 var ret = Observable.Return(ProtectedData.Protect(data, null, DataProtectionScope.CurrentUser));
 #endif
-
-
-                // NB: MemoizedRequests will be null as we're disposing
-                InvalidateAllRequests();
-
                 return ret;
             } 
             catch(Exception ex)
@@ -67,9 +62,6 @@ namespace Akavache
 #else
                 var ret = Observable.Return(ProtectedData.Unprotect(data, null, DataProtectionScope.CurrentUser));
 #endif
-
-                // NB: MemoizedRequests will be null as we're disposing
-                InvalidateAllRequests();
                 return ret;
             } 
             catch(Exception ex)


### PR DESCRIPTION
We added the KeyedOperationQueue but methods like `SafeOpenFileAsync` open
a `FileStream` immediately bypassing the queue. I simply made it a `Func` so it only happens when it's time to queue an operation.

Also removed the `InvalidateAllRequests` call which happens to run immediately as well and caused deadlocking.
