### PR TITLE
Fix parallel usage of Akavache SQLite3 connections

### DIFF
--- a/Akavache.Sqlite3/SqlitePersistentBlobCache.cs
+++ b/Akavache.Sqlite3/SqlitePersistentBlobCache.cs
@@ -22,7 +22,6 @@ namespace Akavache.Sqlite3
         public IServiceProvider ServiceProvider { get; private set; }
 
         readonly SQLiteAsyncConnection _connection;
-        readonly SQLiteConnectionPool _pool;
         readonly MemoizingMRUCache<string, IObservable<CacheElement>> _inflightCache;
         bool disposed = false;
 
@@ -33,8 +32,7 @@ namespace Akavache.Sqlite3
 
             BlobCache.EnsureInitialized();
 
-            _pool = new SQLiteConnectionPool();
-            _connection = new SQLiteAsyncConnection(databaseFile, _pool, storeDateTimeAsTicks: true);
+            _connection = new SQLiteAsyncConnection(databaseFile, storeDateTimeAsTicks: true);
             _connection.CreateTableAsync<CacheElement>();
 
             _inflightCache = new MemoizingMRUCache<string, IObservable<CacheElement>>((key, _) =>
@@ -200,7 +198,6 @@ namespace Akavache.Sqlite3
         public void Dispose()
         {
             _connection.Shutdown()
-                .Finally(() => _pool.Reset())
                 .Multicast(shutdown)
                 .PermaRef();
 


### PR DESCRIPTION
Previously, we were incorrectly reusing SQLite connections on parallel threads, which is Bad™ at best (depending on the version of SQLite you have, it will be more or less tolerant of this). The logic that was existing in this code was based on blocking threads and didn't really work.

Instead, we rewrite the connection pool here:
- Create 'n' connections (currently hardcoded at 6)
- Round-robin between them
- Use `KeyedOperationQueue` with the selected index as the key (meaning, we will asynchronously queue up items to be sent down on a per-connection basis)
## TODO:
- [x] Make sure this actually works
- [x] Backport to GitHub for Windows, make sure it works there too
