### PR TITLE
Added project targets hack for WP8 #67

### DIFF
--- a/Akavache/Akavache_WP8.csproj
+++ b/Akavache/Akavache_WP8.csproj
@@ -155,6 +155,13 @@
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />
   <ProjectExtensions />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Target Name="_SetFullFrameworkFolderToProfile"
+     AfterTargets="GetReferenceAssemblyPaths">
+
+    <PropertyGroup>
+      <_FullFrameworkReferenceAssemblyPaths>$(TargetFrameworkDirectory)</_FullFrameworkReferenceAssemblyPaths>
+    </PropertyGroup>
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Fixes #67 where WP8 projects will not initialize static cache singletons. Added project file hack to workaround bug in WP8 portable lib support as per http://connect.microsoft.com/VisualStudio/feedback/details/770242

Once January 2013 rolls around.....
