### PR TITLE
Backport SQLite3 fixes to Akavache 2.x

### DIFF
--- a/Akavache.Sqlite3/SQLiteAsync.cs
+++ b/Akavache.Sqlite3/SQLiteAsync.cs
@@ -258,7 +258,7 @@ namespace SQLite
 
         public SQLiteConnectionPool(SQLiteConnectionString connectionString, SQLiteOpenFlags flags, int? connectionCount = null)
         {
-            this.connectionCount = connectionCount ?? 6;
+            this.connectionCount = connectionCount ?? 4;
             connInfo = Tuple.Create(connectionString, flags);
             Reset().Wait();
         }


### PR DESCRIPTION
This backports #66 to Akavache 2.x
