### PR TITLE
GetAndFetchLatest invalidates correct cache entry

### DIFF
--- a/Akavache.Portable/JsonSerializationMixin.cs
+++ b/Akavache.Portable/JsonSerializationMixin.cs
@@ -160,6 +160,20 @@ namespace Akavache
         }
 
         /// <summary>
+        /// Returns the time that the key was added to the cache, or returns 
+        /// null if the key isn't in the cache.
+        /// </summary>
+        /// <param name="key">The key to return the date for.</param>
+        /// <returns>The date the key was created on.</returns>
+        public static IObservable<DateTimeOffset?> GetObjectCreatedAt<T>(this IBlobCache This, string key)
+        {
+            var objCache = This as IObjectBlobCache;
+            if (objCache != null) return This.GetCreatedAt(key);
+
+            return This.GetCreatedAt(GetTypePrefixedKey(key, typeof(T)));
+        }
+
+        /// <summary>
         /// This method attempts to returned a cached value, while
         /// simultaneously calling a Func to return the latest value. When the
         /// latest data comes back, it replaces what was previously in the
@@ -193,7 +207,7 @@ namespace Akavache
             DateTimeOffset? absoluteExpiration = null,
             bool shouldInvalidateOnError = false)
         {
-            var fetch = Observable.Defer(() => This.GetCreatedAt(key))
+            var fetch = Observable.Defer(() => This.GetObjectCreatedAt<T>(key))
                 .Select(x => fetchPredicate == null || x == null || fetchPredicate(x.Value))
                 .Where(x => x != false)
                 .SelectMany(async _ => {

--- a/Akavache.Tests/BlobCacheExtensionsFixture.cs
+++ b/Akavache.Tests/BlobCacheExtensionsFixture.cs
@@ -460,6 +460,41 @@ namespace Akavache.Tests
         }
 
         [Fact]
+        public void GetAndFetchLatestCallsFetchPredicate()
+        {
+            var fetchPredicateCalled = false;
+
+            Func<DateTimeOffset, bool> fetchPredicate = d =>
+            {
+                fetchPredicateCalled = true;
+
+                return true;
+            };
+
+            var fetcher = new Func<IObservable<string>>(() => Observable.Return("baz"));
+
+            string path;
+            using (Utility.WithEmptyDirectory(out path))
+            {
+                var fixture = CreateBlobCache(path);
+
+                using (fixture)
+                {
+                    if (fixture is TestBlobCache) return;
+
+                    fixture.InsertObject("foo", "bar").First();
+
+                    fixture.GetAndFetchLatest("foo", fetcher, fetchPredicate)
+                        .First();
+
+                    Assert.True(fetchPredicateCalled);
+                }
+
+                fixture.Shutdown.Wait();
+            }
+        }
+
+        [Fact]
         public void KeysByTypeTest()
         {
             string path;


### PR DESCRIPTION
Update GetAndFetchLatest to use InvalidateObject.
