### PR TITLE
Invalidate Object invalidates untyped entry

### DIFF
--- a/Akavache.Portable/JsonSerializationMixin.cs
+++ b/Akavache.Portable/JsonSerializationMixin.cs
@@ -278,7 +278,7 @@ namespace Akavache
         public static IObservable<Unit> InvalidateObject<T>(this IBlobCache This, string key)
         {
             var objCache = This as IObjectBlobCache;
-            if (objCache != null) objCache.InvalidateObject<T>(key);
+            if (objCache != null) return objCache.InvalidateObject<T>(key);
 
             return This.Invalidate(GetTypePrefixedKey(key, typeof(T)));
         }
@@ -292,7 +292,7 @@ namespace Akavache
         public static IObservable<Unit> InvalidateAllObjects<T>(this IBlobCache This)
         {
             var objCache = This as IObjectBlobCache;
-            if (objCache != null) objCache.InvalidateAllObjects<T>();
+            if (objCache != null) return objCache.InvalidateAllObjects<T>();
             var ret = new AsyncSubject<Unit>();
 
             This.GetAllKeys().Where(x => x.StartsWith(GetTypePrefixedKey("", typeof(T))))


### PR DESCRIPTION
Not 100% sure if this is a bug, but given the other methods like GetObjectAsync I don't think InvalidateObject should be invalidating both the typed and untyped key entries at the same time.
