### PR TITLE
Fix build config param so it actually builds release mode

### DIFF
--- a/buildMac.sh
+++ b/buildMac.sh
@@ -1,3 +1,3 @@
 #!/bin/zsh
 
-/Applications/Xamarin\ Studio.app/Contents/MacOS/mdtool build '--configuration:Release|AnyCPU' Akavache_XSAll.sln
+/Applications/Xamarin\ Studio.app/Contents/MacOS/mdtool build '--configuration:Release' Akavache_XSAll.sln


### PR DESCRIPTION
Silly parameters for mdtool. Just realized that while it was building the right sln config; the project were building in debug.
