### PR TITLE
Retry SQLite3 operations when table is locked

### DIFF
--- a/Akavache.Sqlite3/SQLiteAsync.cs
+++ b/Akavache.Sqlite3/SQLiteAsync.cs
@@ -278,22 +278,14 @@ namespace Akavache.Sqlite3.Internal
                 return operation(conn.Connection);
             }));
 
-            int currentCount = 0;
-            makeRq = makeRq.Catch<T, SQLiteException>(ex => {
-                if (ex.Result != SQLite3.Result.Busy && ex.Result != SQLite3.Result.Locked) 
-                {
-                    return Observable.Throw<T>(ex);
-                }
+            return makeRq.RetryWithBackoffStrategy(tableLockRetries, retryOnError: ex => 
+            {
+                var sqlex = ex as SQLiteException;
+                if (sqlex == null) return false;
 
-                if (currentCount++ > tableLockRetries) 
-                {
-                    return Observable.Throw<T>(ex);
-                }
-
-                return makeRq;
+                return (sqlex.Result == SQLite3.Result.Locked ||
+                    sqlex.Result == SQLite3.Result.Busy);
             });
-
-            return makeRq;
         }
 
         /// <summary>
@@ -360,6 +352,59 @@ namespace Akavache.Sqlite3.Internal
         public SQLiteConnectionWithoutLock (SQLiteConnectionString connectionString, SQLiteOpenFlags flags)
             : base (connectionString.DatabasePath, flags, connectionString.StoreDateTimeAsTicks)
         {
+        }
+    }
+
+    public static class RetryWithBackoffMixin
+    {
+        /// <summary>
+        /// An exponential back off strategy which starts with 1 second and then 4, 9, 16...
+        /// </summary>
+        public static readonly Func<int, TimeSpan> ExponentialBackoff = 
+            n => TimeSpan.FromMilliseconds(Math.Pow(n, 2) * 20);
+
+        /// <summary>
+        /// Returns a cold observable which retries (re-subscribes to) the source observable on error up to the 
+        /// specified number of times or until it successfully terminates. Allows for customizable back off strategy.
+        /// </summary>
+        /// <param name="source">The source observable.</param>
+        /// <param name="retryCount">The number of attempts of running the source observable before failing.</param>
+        /// <param name="strategy">The strategy to use in backing off, exponential by default.</param>
+        /// <param name="retryOnError">A predicate determining for which exceptions to retry. Defaults to all</param>
+        /// <param name="scheduler">The scheduler.</param>
+        /// <returns>
+        /// A cold observable which retries (re-subscribes to) the source observable on error up to the 
+        /// specified number of times or until it successfully terminates.
+        /// </returns>
+        public static IObservable<T> RetryWithBackoffStrategy<T>(
+            this IObservable<T> source, 
+            int retryCount = 3,
+            Func<int, TimeSpan> strategy = null,
+            Func<Exception, bool> retryOnError = null,
+            IScheduler scheduler = null)
+        {
+            strategy = strategy ?? ExponentialBackoff;
+            scheduler = scheduler ?? BlobCache.TaskpoolScheduler;
+
+            if (retryOnError == null) 
+            {
+                retryOnError = _ => true;
+            }
+
+            int attempt = 0;
+
+            return Observable.Defer(() =>
+            {
+                return ((++attempt == 1) ? source : source.DelaySubscription(strategy(attempt - 1), scheduler))
+                    .Select(item => new Tuple<bool, T, Exception>(true, item, null))
+                    .Catch<Tuple<bool, T, Exception>, Exception>(e => retryOnError(e)
+                        ? Observable.Throw<Tuple<bool, T, Exception>>(e)
+                        : Observable.Return(new Tuple<bool, T, Exception>(false, default(T), e)));
+            })
+            .Retry(retryCount)
+            .SelectMany(t => t.Item1
+                ? Observable.Return(t.Item2)
+                : Observable.Throw<T>(t.Item3));
         }
     }
 }


### PR DESCRIPTION
Just like it says on the tin, if the table is locked or busy, we retry the operation.

Fixes #122
