### PR TITLE
Ensure Akavache.Sqlite3 type information is discoverable on iOS

### DIFF
--- a/Akavache.Sqlite3/Akavache.Sqlite3.nuspec
+++ b/Akavache.Sqlite3/Akavache.Sqlite3.nuspec
@@ -19,5 +19,6 @@
   </metadata>
   <files>
     <file src="bin\Release\Portable-Net45+Win8+WP8+Wpa81\Akavache.Sqlite3.*" target="lib\Portable-Net45+Win8+WP8+Wpa81" />
+    <file src="content\*" target="content" />
   </files>
 </package>

--- a/Akavache.Sqlite3/content/AkavacheSqliteLinkerOverride.cs
+++ b/Akavache.Sqlite3/content/AkavacheSqliteLinkerOverride.cs
@@ -1,0 +1,21 @@
+using System;
+using Akavache.Sqlite3;
+
+// Note: This class file is *required* for iOS to work correctly, and is 
+// also a good idea for Android if you enable "Link All Assemblies".
+namespace WorkaroundAssemblyEarlyLoadingAndPreventLinkerStripping
+{
+    [Preserve]
+    public static class LinkerPreserve
+    {
+        static LinkerPreserve()
+        {
+            Console.WriteLine(typeof(SQLitePersistentBlobCache));
+        }
+    }
+
+
+    public class PreserveAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
Fixes #164 by ensuring that SQLite3's assembly is loaded on startup, so that `Type.GetType` can get to it
