### PR TITLE
Improve battery efficiency

### DIFF
--- a/Akavache.Sqlite3/OperationQueueCoalescing.cs
+++ b/Akavache.Sqlite3/OperationQueueCoalescing.cs
@@ -252,6 +252,7 @@ namespace Akavache.Sqlite3
                 case OperationType.GetKeysSqliteOperation:
                 case OperationType.InvalidateAllSqliteOperation:
                 case OperationType.VacuumSqliteOperation:
+                case OperationType.DoNothing:
                     return default(string);
                 default:
                     throw new ArgumentException("Unknown operation");

--- a/Akavache.Sqlite3/Operations.cs
+++ b/Akavache.Sqlite3/Operations.cs
@@ -21,6 +21,7 @@ namespace Akavache.Sqlite3
 
     enum OperationType 
     {
+        DoNothing,
         BulkSelectSqliteOperation,
         BulkSelectByTypeSqliteOperation,
         BulkInsertSqliteOperation,


### PR DESCRIPTION
Don't fire timers every 2sec, increase the timeout to 30sec and ensure that shutdown doesn't have to wait the entire time
