### PR TITLE
Add an explicit key to download mixin functions

### DIFF
--- a/Akavache/HttpMixin.cs
+++ b/Akavache/HttpMixin.cs
@@ -58,6 +58,33 @@ namespace Akavache
             }
         }
 
+        /// <summary>
+        /// Download data from an HTTP URL and insert the result into the
+        /// cache. If the data is already in the cache, this returns
+        /// a cached value. An explicit key is provided rather than the URL itself.
+        /// </summary>
+        /// <param name="key">The key to store with.</param>
+        /// <param name="url">The URL to download.</param>
+        /// <param name="headers">An optional Dictionary containing the HTTP
+        /// request headers.</param>
+        /// <param name="fetchAlways">Force a web request to always be issued, skipping the cache.</param>
+        /// <param name="absoluteExpiration">An optional expiration date.</param>
+        /// <returns>The data downloaded from the URL.</returns>
+        public IObservable<byte[]> DownloadUrl(IBlobCache This, string key, string url, IDictionary<string, string> headers = null, bool fetchAlways = false, DateTimeOffset? absoluteExpiration = null)
+        {
+            var doFetch = new Func<IObservable<byte[]>>(() =>
+                MakeWebRequest(new Uri(url), headers).SelectMany(x => ProcessAndCacheWebResponse(x, url, absoluteExpiration)));
+
+            if (fetchAlways)
+            {
+                return This.GetAndFetchLatest(key, doFetch, absoluteExpiration: absoluteExpiration).TakeLast(1);
+            }
+            else
+            {
+                return This.GetOrFetchObject(key, doFetch, absoluteExpiration);
+            }
+        }
+
         IObservable<byte[]> ProcessAndCacheWebResponse(WebResponse wr, string url, DateTimeOffset? absoluteExpiration)
         {
             var hwr = (HttpWebResponse)wr;

--- a/Akavache/Portable/BitmapImageExtensions.cs
+++ b/Akavache/Portable/BitmapImageExtensions.cs
@@ -45,6 +45,23 @@ namespace Akavache
         }
 
         /// <summary>
+        /// A combination of DownloadUrl and LoadImage, this method fetches an
+        /// image from a remote URL (using the cached value if possible) and
+        /// returns the image. 
+        /// </summary>
+        /// <param name="key">The key to store with.</param>
+        /// <param name="url">The URL to download.</param>
+        /// <returns>A Future result representing the bitmap image. This
+        /// Observable is guaranteed to be returned on the UI thread.</returns>
+        public static IObservable<IBitmap> LoadImageFromUrl(this IBlobCache This, string key, string url, bool fetchAlways = false, float? desiredWidth = null, float? desiredHeight = null, DateTimeOffset? absoluteExpiration = null)
+        {
+            return This.DownloadUrl(key, url, null, fetchAlways, absoluteExpiration)
+                .SelectMany(ThrowOnBadImageBuffer)
+                .SelectMany(x => bytesToImage(x, desiredWidth, desiredHeight));
+        }
+
+
+        /// <summary>
         /// Converts bad image buffers into an exception
         /// </summary>
         /// <returns>The byte[], or OnError if the buffer is corrupt (empty or 

--- a/Akavache/Portable/HttpMixin.cs
+++ b/Akavache/Portable/HttpMixin.cs
@@ -10,6 +10,7 @@ namespace Akavache
     public interface IAkavacheHttpMixin
     {
         IObservable<byte[]> DownloadUrl(IBlobCache This, string url, IDictionary<string, string> headers = null, bool fetchAlways = false, DateTimeOffset? absoluteExpiration = null);
+        IObservable<byte[]> DownloadUrl(IBlobCache This, string key, string url, IDictionary<string, string> headers = null, bool fetchAlways = false, DateTimeOffset? absoluteExpiration = null);
     }
 
     public static class HttpMixinExtensions
@@ -30,5 +31,24 @@ namespace Akavache
             var mixin = Locator.Current.GetService<IAkavacheHttpMixin>();
             return mixin.DownloadUrl(This, url, headers, fetchAlways, absoluteExpiration);
         }
+
+        /// <summary>
+        /// Download data from an HTTP URL and insert the result into the
+        /// cache. If the data is already in the cache, this returns
+        /// a cached value. An explicit key is provided rather than the URL itself.
+        /// </summary>
+        /// <param name="key">The key to store with.</param>
+        /// <param name="url">The URL to download.</param>
+        /// <param name="headers">An optional Dictionary containing the HTTP
+        /// request headers.</param>
+        /// <param name="fetchAlways">Force a web request to always be issued, skipping the cache.</param>
+        /// <param name="absoluteExpiration">An optional expiration date.</param>
+        /// <returns>The data downloaded from the URL.</returns>
+        public static IObservable<byte[]> DownloadUrl(this IBlobCache This, string key, string url, IDictionary<string, string> headers = null, bool fetchAlways = false, DateTimeOffset? absoluteExpiration = null)
+        {
+            var mixin = Locator.Current.GetService<IAkavacheHttpMixin>();
+            return mixin.DownloadUrl(This, key, url, headers, fetchAlways, absoluteExpiration);
+        }
+
     }
 }


### PR DESCRIPTION
In this proposed change, I've extended DownloadUrl and LoadImageFromUrl functions to accept a fixed key when storing data from a given URL.  Often I pull a resource "<someguid>.dat" for a game but it's shared data between any number of server instances. I don't care which of those servers the data came from just that I cached it - so the URL is "too precise" for my needs :) 

Fixes #170 
