### PR TITLE
Changed Blob Cache to use an IBlobCacheProvider

### DIFF
--- a/src/Akavache.Sqlite3/Akavache.Sqlite3.csproj
+++ b/src/Akavache.Sqlite3/Akavache.Sqlite3.csproj
@@ -31,6 +31,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Registrations.cs" />
     <Compile Include="SQLite.cs" />
+    <Compile Include="SQLiteBlobCacheProvider.cs" />
     <Compile Include="SqlitePersistentBlobCacheNext.cs" />
     <Compile Include="SQLiteEncryptedBlobCache.cs" />
     <Compile Include="OperationQueueCoalescing.cs" />

--- a/src/Akavache.Sqlite3/Registrations.cs
+++ b/src/Akavache.Sqlite3/Registrations.cs
@@ -15,31 +15,7 @@ namespace Akavache.Sqlite3
     {
         public void Register(IMutableDependencyResolver resolver)
         {
-            // NB: We want the most recently registered fs, since there really 
-            // only should be one 
-            var fs = Locator.Current.GetService<IFilesystemProvider>();
-            if (fs == null)
-            {
-                throw new Exception("Failed to initialize Akavache properly. Do you have a reference to Akavache.dll?");
-            }
-
-            var localCache = new Lazy<IBlobCache>(() =>{
-                fs.CreateRecursive(fs.GetDefaultLocalMachineCacheDirectory()).SubscribeOn(BlobCache.TaskpoolScheduler).Wait();
-                return new SQLitePersistentBlobCache(Path.Combine(fs.GetDefaultLocalMachineCacheDirectory(), "blobs.db"), BlobCache.TaskpoolScheduler);
-            });
-            resolver.Register(() => localCache.Value, typeof(IBlobCache), "LocalMachine");
-
-            var userAccount = new Lazy<IBlobCache>(() =>{
-                fs.CreateRecursive(fs.GetDefaultRoamingCacheDirectory()).SubscribeOn(BlobCache.TaskpoolScheduler).Wait();
-                return new SQLitePersistentBlobCache(Path.Combine(fs.GetDefaultRoamingCacheDirectory(), "userblobs.db"), BlobCache.TaskpoolScheduler);
-            });
-            resolver.Register(() => userAccount.Value, typeof(IBlobCache), "UserAccount");
-                
-            var secure = new Lazy<ISecureBlobCache>(() => {
-                fs.CreateRecursive(fs.GetDefaultSecretCacheDirectory()).SubscribeOn(BlobCache.TaskpoolScheduler).Wait();
-                return new SQLiteEncryptedBlobCache(Path.Combine(fs.GetDefaultSecretCacheDirectory(), "secret.db"), Locator.Current.GetService<IEncryptionProvider>(), BlobCache.TaskpoolScheduler);
-            });
-            resolver.Register(() => secure.Value, typeof(ISecureBlobCache), null);
+            resolver.RegisterLazySingleton(() => new SQLiteBlobCacheProvider(), typeof(IBlobCacheProvider), null);
         }
     }
 }

--- a/src/Akavache.Sqlite3/SQLiteBlobCacheProvider.cs
+++ b/src/Akavache.Sqlite3/SQLiteBlobCacheProvider.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Splat;
+
+namespace Akavache.Sqlite3
+{
+    public class SQLiteBlobCacheProvider : IBlobCacheProvider
+    {
+        IFilesystemProvider getFilesystemProvider()
+        {
+            // NB: We want the most recently registered fs, since there really 
+            // only should be one 
+            var fs = Locator.Current.GetService<IFilesystemProvider>();
+            if (fs == null)
+            {
+                throw new Exception("Failed to initialize Akavache properly. Do you have a reference to Akavache.dll?");
+            }
+
+            return fs;
+        }   
+
+        public virtual IBlobCache CreateLocalMachine(string fileName)
+        {
+            var fs = getFilesystemProvider();
+            fs.CreateRecursive(fs.GetDefaultLocalMachineCacheDirectory()).SubscribeOn(BlobCache.TaskpoolScheduler).Wait();
+            return new SQLitePersistentBlobCache(Path.Combine(fs.GetDefaultLocalMachineCacheDirectory(), fileName), BlobCache.TaskpoolScheduler);
+        }
+
+        public virtual IBlobCache CreateUserAccount(string fileName)
+        {
+            var fs = getFilesystemProvider();
+            fs.CreateRecursive(fs.GetDefaultRoamingCacheDirectory()).SubscribeOn(BlobCache.TaskpoolScheduler).Wait();
+            return new SQLitePersistentBlobCache(Path.Combine(fs.GetDefaultRoamingCacheDirectory(), fileName), BlobCache.TaskpoolScheduler);
+        }
+
+        public virtual ISecureBlobCache CreateSecure(string fileName)
+        {
+            var fs = getFilesystemProvider();
+            fs.CreateRecursive(fs.GetDefaultSecretCacheDirectory()).SubscribeOn(BlobCache.TaskpoolScheduler).Wait();
+            return new SQLiteEncryptedBlobCache(Path.Combine(fs.GetDefaultSecretCacheDirectory(), fileName), Locator.Current.GetService<IEncryptionProvider>(), BlobCache.TaskpoolScheduler);
+        }
+    }
+}

--- a/src/Akavache.Tests/BlobCacheExtensionsFixture.cs
+++ b/src/Akavache.Tests/BlobCacheExtensionsFixture.cs
@@ -616,6 +616,52 @@ namespace Akavache.Tests
                 Assert.True(new FileInfo(dbPath).Length < size);
             }
         }
+
+
+        [Fact]
+        public void CreateLocalCache()
+        {
+            BlobCache.ApplicationName = "TestRunner";
+            var cache1 = (SQLitePersistentBlobCache)BlobCache.LocalMachineCreateNew();
+            var cache2 = (SQLitePersistentBlobCache)BlobCache.LocalMachineCreateNew();
+
+            Assert.Equal(BlobCache.LocalMachine, BlobCache.LocalMachine);
+            Assert.NotNull(cache1);
+            Assert.NotNull(cache2);
+            Assert.NotEqual(cache1, cache2);
+
+            Assert.True(cache1.Connection.DatabasePath.EndsWith("\\blobs.db"));
+        }
+
+        [Fact]
+        public void CreateSecureCache()
+        {
+            BlobCache.ApplicationName = "TestRunner";
+            var cache1 = (SQLitePersistentBlobCache)BlobCache.SecureCreateNew();
+            var cache2 = (SQLitePersistentBlobCache)BlobCache.SecureCreateNew();
+
+            Assert.Equal(BlobCache.Secure, BlobCache.Secure);
+            Assert.NotNull(cache1);
+            Assert.NotNull(cache2);
+            Assert.NotEqual(cache1, cache2);
+
+            Assert.True(cache1.Connection.DatabasePath.EndsWith("\\secret.db"));
+        }
+
+        [Fact]
+        public void CreateUserAccountCache()
+        {
+            BlobCache.ApplicationName = "TestRunner";
+            var cache1 = (SQLitePersistentBlobCache)BlobCache.UserAccountCreateNew();
+            var cache2 = (SQLitePersistentBlobCache)BlobCache.UserAccountCreateNew();
+
+            Assert.Equal(BlobCache.UserAccount, BlobCache.UserAccount);
+            Assert.NotNull(cache1);
+            Assert.NotNull(cache2);
+            Assert.NotEqual(cache1, cache2);
+
+            Assert.True(cache1.Connection.DatabasePath.EndsWith("\\userblobs.db"));
+        }
     }
 
     public class EncryptedSqliteBlobCacheExtensionsFixture : BlobCacheExtensionsFixture

--- a/src/Akavache/Akavache_Monodroid.csproj
+++ b/src/Akavache/Akavache_Monodroid.csproj
@@ -153,8 +153,10 @@
     </Compile>
     <Compile Include="EncryptionProvider.cs" />
     <Compile Include="Portable\ExceptionHelper.cs" />
+    <Compile Include="Portable\IBlobCacheProvider.cs" />
     <Compile Include="Portable\IEncryptionProvider.cs" />
     <Compile Include="Portable\InMemoryBlobCache.cs" />
+    <Compile Include="Portable\InMemoryBlobCacheProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="HttpMixin.cs" />
     <Compile Include="IsolatedStorageProvider.cs" />

--- a/src/Akavache/Akavache_Net45.csproj
+++ b/src/Akavache/Akavache_Net45.csproj
@@ -96,9 +96,11 @@
     <Compile Include="Portable\ExceptionHelper.cs" />
     <Compile Include="Portable\HttpMixin.cs" />
     <Compile Include="Portable\IBlobCache.cs" />
+    <Compile Include="Portable\IBlobCacheProvider.cs" />
     <Compile Include="Portable\IEncryptionProvider.cs" />
     <Compile Include="Portable\IKeyedOperationQueue.cs" />
     <Compile Include="Portable\InMemoryBlobCache.cs" />
+    <Compile Include="Portable\InMemoryBlobCacheProvider.cs" />
     <Compile Include="Portable\JsonSerializationMixin.cs" />
     <Compile Include="Portable\KeyedOperationQueue.cs" />
     <Compile Include="Portable\LoginInfo.cs" />

--- a/src/Akavache/Akavache_Portable.csproj
+++ b/src/Akavache/Akavache_Portable.csproj
@@ -53,8 +53,10 @@
     <Compile Include="Portable\ExceptionHelper.cs" />
     <Compile Include="Portable\HttpMixin.cs" />
     <Compile Include="Portable\IBlobCache.cs" />
+    <Compile Include="Portable\IBlobCacheProvider.cs" />
     <Compile Include="Portable\IEncryptionProvider.cs" />
     <Compile Include="Portable\IKeyedOperationQueue.cs" />
+    <Compile Include="Portable\InMemoryBlobCacheProvider.cs" />
     <Compile Include="Portable\JsonSerializationMixin.cs" />
     <Compile Include="Portable\KeyedOperationQueue.cs" />
     <Compile Include="Portable\LoginInfo.cs" />

--- a/src/Akavache/Akavache_WinRT.csproj
+++ b/src/Akavache/Akavache_WinRT.csproj
@@ -45,8 +45,10 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Portable\ExceptionHelper.cs" />
+    <Compile Include="Portable\IBlobCacheProvider.cs" />
     <Compile Include="Portable\IEncryptionProvider.cs" />
     <Compile Include="Portable\InMemoryBlobCache.cs" />
+    <Compile Include="Portable\InMemoryBlobCacheProvider.cs" />
     <Compile Include="WinRT\WinRTEncryptionProvider.cs" />
     <Compile Include="HttpMixin.cs" />
     <Compile Include="MD5.cs" />

--- a/src/Akavache/Akavache_XamarinIOS.csproj
+++ b/src/Akavache/Akavache_XamarinIOS.csproj
@@ -69,8 +69,10 @@
     </Compile>
     <Compile Include="EncryptionProvider.cs" />
     <Compile Include="Portable\ExceptionHelper.cs" />
+    <Compile Include="Portable\IBlobCacheProvider.cs" />
     <Compile Include="Portable\IEncryptionProvider.cs" />
     <Compile Include="Portable\InMemoryBlobCache.cs" />
+    <Compile Include="Portable\InMemoryBlobCacheProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="IsolatedStorageProvider.cs" />
     <Compile Include="MD5.cs" />

--- a/src/Akavache/Akavache_XamarinMac.csproj
+++ b/src/Akavache/Akavache_XamarinMac.csproj
@@ -85,6 +85,8 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Portable\IBlobCacheProvider.cs" />
+    <Compile Include="Portable\InMemoryBlobCacheProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="HttpMixin.cs" />
     <Compile Include="MD5.cs" />
@@ -123,9 +125,7 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <Folder Include="Portable\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/src/Akavache/Portable/BlobCache.cs
+++ b/src/Akavache/Portable/BlobCache.cs
@@ -167,6 +167,63 @@ namespace Akavache
             return ret.ToTask();
         }
 
+
+        /// <summary>
+        /// Returns a new ISecureBlobCache with every call. This is used to create a Secure Blob Cache
+        /// for you to use and manage from your own application
+        /// </summary> 
+        public static ISecureBlobCache SecureCreateNew()
+        {
+            return SecureCreateNew("secret.db");
+        }
+
+        /// <summary>
+        /// Returns a new ISecureBlobCache with every call. This is used to create a Secure Blob Cache
+        /// for you to use and manage from your own application
+        /// </summary> 
+        public static ISecureBlobCache SecureCreateNew(string fileName)
+        {
+            return Locator.Current.GetService<IBlobCacheProvider>().CreateSecure(fileName);
+        }
+
+
+        /// <summary>
+        /// Returns a new IBlobCache with every call. This is used to create a Local Blob Cache
+        /// for you to use and manage from your own application
+        /// </summary>
+        public static IBlobCache LocalMachineCreateNew()
+        {
+            return LocalMachineCreateNew("blobs.db");
+        }
+
+        /// <summary>
+        /// Returns a new IBlobCache with every call. This is used to create a Local Blob Cache
+        /// for you to use and manage from your own application
+        /// </summary>
+        public static IBlobCache LocalMachineCreateNew(string fileName)
+        {
+            return Locator.Current.GetService<IBlobCacheProvider>().CreateLocalMachine(fileName);
+        }
+
+
+        /// <summary>
+        /// Returns a new IBlobCache with every call. This is used to create a User Blob Cache
+        /// for you to use and manage from your own application
+        /// </summary>
+        public static IBlobCache UserAccountCreateNew()
+        {
+            return UserAccountCreateNew("userblobs.db");
+        }
+
+        /// <summary>
+        /// Returns a new IBlobCache with every call. This is used to create a User Blob Cache
+        /// for you to use and manage from your own application
+        /// </summary>
+        public static IBlobCache UserAccountCreateNew(string fileName)
+        {
+            return Locator.Current.GetService<IBlobCacheProvider>().CreateUserAccount(fileName);
+        }
+
 #if PORTABLE
         static IScheduler TaskpoolOverride;
         public static IScheduler TaskpoolScheduler 

--- a/src/Akavache/Portable/IBlobCacheProvider.cs
+++ b/src/Akavache/Portable/IBlobCacheProvider.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Akavache
+{
+    public interface IBlobCacheProvider
+    {
+        IBlobCache CreateLocalMachine(string fileName);
+        IBlobCache CreateUserAccount(string fileName);
+        ISecureBlobCache CreateSecure(string fileName);
+    }
+}

--- a/src/Akavache/Portable/InMemoryBlobCacheProvider.cs
+++ b/src/Akavache/Portable/InMemoryBlobCacheProvider.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Akavache
+{
+    public class InMemoryBlobCacheProvider : IBlobCacheProvider
+    {
+        public IBlobCache CreateLocalMachine(string fileName)
+        {
+            return new InMemoryBlobCache();
+        }
+
+        public ISecureBlobCache CreateSecure(string fileName)
+        {
+            return new InMemoryBlobCache();
+        }
+
+        public IBlobCache CreateUserAccount(string fileName)
+        {
+            return new InMemoryBlobCache();
+        }
+    }
+}

--- a/src/Akavache/Registrations.cs
+++ b/src/Akavache/Registrations.cs
@@ -40,10 +40,11 @@ namespace Akavache
             var enc = new EncryptionProvider();
 #endif
             resolver.Register(() => enc, typeof(IEncryptionProvider), null);
+            resolver.RegisterLazySingleton(() => new InMemoryBlobCacheProvider(), typeof(IBlobCacheProvider), null);
 
-            var localCache = new Lazy<IBlobCache>(() => new InMemoryBlobCache());
-            var userAccount = new Lazy<IBlobCache>(() => new InMemoryBlobCache());
-            var secure = new Lazy<ISecureBlobCache>(() => new InMemoryBlobCache());
+            var localCache = new Lazy<IBlobCache>(() => resolver.GetService<IBlobCacheProvider>().CreateLocalMachine("blobs.db"));
+            var userAccount = new Lazy<IBlobCache>(() => resolver.GetService<IBlobCacheProvider>().CreateLocalMachine("userblobs.db"));
+            var secure = new Lazy<ISecureBlobCache>(() => resolver.GetService<IBlobCacheProvider>().CreateSecure("secret.db"));
 
             resolver.Register(() => localCache.Value, typeof(IBlobCache), "LocalMachine");
             resolver.Register(() => userAccount.Value, typeof(IBlobCache), "UserAccount");


### PR DESCRIPTION
Changed Splat registrations to use an IBlobCacheProvider so how the cache is created can be reused and tapped into more easily.  Static caches retain current behavior. Also added some static helpers to BlobCache

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
How Blob Caches are constructed isn't really exposed at all to a user. If I don't want to to use the static helpers I don't have a great way to reuse how Akavache news up the Blob Caches.
https://github.com/akavache/Akavache/issues/342

**What is the new behavior (if this is a feature change)?**

How BlobCaches are created currently can't be reused very easily and overall I think this leads to some difficulty for new users with implementing the life cycle correctly in something like mobile apps.  I set it up to register two different types of IBlobCacheProviders. 


**Does this PR introduce a breaking change?**
It shouldn't. If someone was registering on top of the current Splat registrations (i.e. "UserAccount") those should still work just fine


**Please check if the PR fulfills these requirements**
- [ ] The commit follows our guidelines: https://github.com/Akavache/Akavache/blob/master/CONTRIBUTING.md
- [X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
If how I did this is something that is appealing and gets merged I'll add some additional docs around these.

My initial thought was just to add an additional Splat registration with Func's but then I decided to go the provider route
Here is that branch in case anyone is interested
https://github.com/PureWeen/Akavache/tree/added_splat_registration_to_new_up_caches
