### PR TITLE
Use Task.Run to start OperationQueue.

### DIFF
--- a/src/Akavache.Sqlite3/OperationQueue.cs
+++ b/src/Akavache.Sqlite3/OperationQueue.cs
@@ -70,7 +70,7 @@ namespace Akavache.Sqlite3
             if (start != null) return start;
 
             shouldQuit = new CancellationTokenSource();
-            var task = new Task(async () => 
+            var task = Task.Run(async () => 
             {
                 var toProcess = new List<OperationQueueItem>();
 
@@ -130,9 +130,7 @@ namespace Akavache.Sqlite3
                         }
                     }
                 }
-            }, TaskCreationOptions.LongRunning);
-
-            task.Start();
+            });
 
             return (start = Disposable.Create(() => 
             {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

See #406

**What is the new behavior (if this is a feature change)?**

Use `Task.Run` to start `OperationQueue`'s processing task rather than using the constructor and then calling `task.Start`. This ensures two things:

1. The `TaskScheduler.Default` scheduler is used, which will be a threadpool scheduler
2. That `task` tracks the running of the entire task: previously the task will have completed when it `await`ed as the `Task` constructor accepts an `Action` and not a `Func<Task>`

Note that `TaskCreationOptions.LongRunning` is no longer being passed in, but according to https://blog.stephencleary.com/2013/08/startnew-is-dangerous.html that parameter is just an "optimization hint" and the the threadpool should adjust to the long-running task automatically.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/Akavache/Akavache/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I'm not quite sure what a test/docs would look like for this?
