### PR TITLE
Fix the SourceLink package to use Microsofts.

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -31,6 +31,6 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
-		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" /> 
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Change from using the deprecated library to use the same one that Rx, RxUI use.


**What is the current behavior? (You can also link to an open issue here)**
Use a deprecated library.


**What is the new behavior (if this is a feature change)?**
Use the use library which will put correct sourcelink data in.


**Does this PR introduce a breaking change?**
Shouldn't.
