### PR TITLE
housekeeping: Update cake/reactiveui/splat/json.net and other depende…

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -2,21 +2,21 @@
 // ADDINS
 //////////////////////////////////////////////////////////////////////
 
-#addin "nuget:?package=Cake.FileHelpers&version=2.0.0"
-#addin "nuget:?package=Cake.Coveralls&version=0.8.0"
-#addin "nuget:?package=Cake.PinNuGetDependency&version=3.0.1"
-#addin "nuget:?package=Cake.Powershell&version=0.4.3"
+#addin "nuget:?package=Cake.FileHelpers&version=3.1.0"
+#addin "nuget:?package=Cake.Coveralls&version=0.9.0"
+#addin "nuget:?package=Cake.PinNuGetDependency&version=3.1.0"
+#addin "nuget:?package=Cake.Powershell&version=0.4.7"
 
 //////////////////////////////////////////////////////////////////////
 // TOOLS
 //////////////////////////////////////////////////////////////////////
 
-#tool "nuget:?package=GitReleaseManager&version=0.7.0"
+#tool "nuget:?package=GitReleaseManager&version=0.7.1"
 #tool "nuget:?package=coveralls.io&version=1.4.2"
 #tool "nuget:?package=OpenCover&version=4.6.519"
-#tool "nuget:?package=ReportGenerator&version=3.1.2"
-#tool "nuget:?package=vswhere&version=2.4.1"
-#tool "nuget:?package=xunit.runner.console&version=2.4.0"
+#tool "nuget:?package=ReportGenerator&version=4.0.4"
+#tool "nuget:?package=vswhere&version=2.5.2"
+#tool "nuget:?package=xunit.runner.console&version=2.4.1"
 
 
 //////////////////////////////////////////////////////////////////////

--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 tools\nuget\nuget.exe update -self
 tools\nuget\nuget.exe install xunit.runner.console -OutputDirectory tools -ExcludeVersion
-tools\nuget\nuget.exe install Cake -OutputDirectory tools -ExcludeVersion -Version 0.22.1
+tools\nuget\nuget.exe install Cake -OutputDirectory tools -ExcludeVersion -Version 0.31.0
 
 tools\Cake\Cake.exe build.cake --target=%1  -Verbosity=Diagnostic
 

--- a/src/Akavache.Core/Akavache.Core.csproj
+++ b/src/Akavache.Core/Akavache.Core.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
-    <PackageReference Include="Splat" Version="4.0.2" />
+    <PackageReference Include="Splat" Version="5.1.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
@@ -37,6 +37,7 @@
     <Compile Include="Platforms\windows-common\**\*.cs" />
     <Compile Include="Platforms\net461\**\*.cs" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('uap')) ">
@@ -57,6 +58,7 @@
     <Compile Include="Platforms\mac\**\*.cs" />
     <Compile Include="Platforms\xamarin-common\**\*.cs" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="netstandard" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">

--- a/src/Akavache.Mobile/Akavache.Mobile.csproj
+++ b/src/Akavache.Mobile/Akavache.Mobile.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="reactiveui" Version="8.5.1" />
-		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="reactiveui" Version="9.4.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
 		<PackageReference Include="System.Reactive" Version="4.0.0" />
-		<PackageReference Include="Splat" Version="4.0.2" />
+		<PackageReference Include="Splat" Version="5.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Akavache.Sqlite3/Akavache.Sqlite3.csproj
+++ b/src/Akavache.Sqlite3/Akavache.Sqlite3.csproj
@@ -19,9 +19,9 @@
   <ItemGroup>
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="1.1.11" />
     <PackageReference Include="SQLitePCLRaw.core" Version="1.1.11" />
-		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+		<PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
 		<PackageReference Include="System.Reactive" Version="4.0.0" />
-		<PackageReference Include="Splat" Version="4.0.2" />
+		<PackageReference Include="Splat" Version="5.1.4" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Akavache.Tests/Akavache.Tests.csproj
+++ b/src/Akavache.Tests/Akavache.Tests.csproj
@@ -7,21 +7,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-		<PackageReference Include="xunit" Version="2.4.0" />
-		<PackageReference Include="xunit.runner.console" Version="2.4.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-		<PackageReference Include="Xunit.StaFact" Version="0.2.9" />
-    <PackageReference Include="reactiveui" Version="8.5.1" />
-    <PackageReference Include="ReactiveUI.Testing" Version="8.5.1" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.console" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+		<PackageReference Include="Xunit.StaFact" Version="0.3.13" />
+    <PackageReference Include="reactiveui" Version="9.4.1" />
+    <PackageReference Include="ReactiveUI.Testing" Version="9.4.1" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3.v110_xp" Version="1.1.11" />
-		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+		<PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
 		<PackageReference Include="System.Reactive" Version="4.0.0" />
-		<PackageReference Include="Splat" Version="4.0.2" />
+		<PackageReference Include="Splat" Version="5.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Akavache.Tests/BlobCacheExtensionsFixture.cs
+++ b/src/Akavache.Tests/BlobCacheExtensionsFixture.cs
@@ -14,6 +14,7 @@ using Xunit;
 using System.Threading;
 using System.Reactive.Concurrency;
 using System.Threading.Tasks;
+using DynamicData;
 
 namespace Akavache.Tests
 {
@@ -274,7 +275,8 @@ namespace Akavache.Tests
                     var fixture = CreateBlobCache(path);
                     try
                     {
-                        var result1 = fixture.GetOrFetchObject("foo", fetcher).CreateCollection();
+                        
+                        fixture.GetOrFetchObject("foo", fetcher).ToObservableChangeSet(ImmediateScheduler.Instance).Bind(out var result1).Subscribe();
 
                         Assert.Equal(0, result1.Count);
 
@@ -282,7 +284,7 @@ namespace Akavache.Tests
 
                         // Nobody's returned yet, cache is empty, we should have called the fetcher
                         // once to get a result
-                        var result2 = fixture.GetOrFetchObject("foo", fetcher).CreateCollection();
+                        fixture.GetOrFetchObject("foo", fetcher).ToObservableChangeSet(ImmediateScheduler.Instance).Bind(out var result2).Subscribe();
                         Assert.Equal(0, result1.Count);
                         Assert.Equal(0, result2.Count);
                         Assert.Equal(1, callCount);
@@ -290,7 +292,7 @@ namespace Akavache.Tests
                         sched.AdvanceToMs(750);
 
                         // Same as above, result1-3 are all listening to the same fetch
-                        var result3 = fixture.GetOrFetchObject("foo", fetcher).CreateCollection();
+                        fixture.GetOrFetchObject("foo", fetcher).ToObservableChangeSet(ImmediateScheduler.Instance).Bind(out var result3).Subscribe();
                         Assert.Equal(0, result1.Count);
                         Assert.Equal(0, result2.Count);
                         Assert.Equal(0, result3.Count);
@@ -305,7 +307,7 @@ namespace Akavache.Tests
 
                         // Making a new call, but the cache has an item, this shouldn't result
                         // in a fetcher call either
-                        var result4 = fixture.GetOrFetchObject("foo", fetcher).CreateCollection();
+                        fixture.GetOrFetchObject("foo", fetcher).ToObservableChangeSet(ImmediateScheduler.Instance).Bind(out var result4).Subscribe();
                         sched.AdvanceToMs(2500);
                         Assert.Equal(1, result1.Count);
                         Assert.Equal(1, result2.Count);
@@ -316,7 +318,7 @@ namespace Akavache.Tests
                         // Making a new call, but with a new key - this *does* result in a fetcher
                         // call. Result1-4 shouldn't get any new items, and at t=3000, we haven't
                         // returned from the call made at t=2500 yet
-                        var result5 = fixture.GetOrFetchObject("bar", fetcher).CreateCollection();
+                        fixture.GetOrFetchObject("bar", fetcher).ToObservableChangeSet(ImmediateScheduler.Instance).Bind(out var result5).Subscribe();
                         sched.AdvanceToMs(3000);
                         Assert.Equal(1, result1.Count);
                         Assert.Equal(1, result2.Count);

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Nerdbank.GitVersioning" Version="2.2.3" PrivateAssets="all" />
+		<PackageReference Include="Nerdbank.GitVersioning" Version="2.2.33" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "1.6.47"
+        "MSBuild.Sdk.Extras": "1.6.61"
     }
 }


### PR DESCRIPTION
…ncies

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

housekeeping

**What is the current behavior? (You can also link to an open issue here)**

Old versions of reactiveui/splat/cake/json.net/msbuild.sdk.extras/ms test/xunit update those.

**What is the new behavior (if this is a feature change)?**
The updated nuget references, also updated tests to match using dynamicdata instead of the deprecated reactiveui collections interfaces.


**Does this PR introduce a breaking change?**
The main user facing updates to the dependencies are ReactiveUI, Splat, Newtonsoft.JSON, all other dependencies are in the test projects or cake scripts so will be minimal impact to users.
