### PR TITLE
housekeeping: Handle the DateTimeOffset cause where BSON data is already Date

### DIFF
--- a/src/Akavache.Core/JsonDateTimeOffsetTickConverter.cs
+++ b/src/Akavache.Core/JsonDateTimeOffsetTickConverter.cs
@@ -19,6 +19,11 @@ namespace Akavache
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
+            if (reader.TokenType == JsonToken.Date)
+            {
+                return (DateTimeOffset)reader.Value;
+            }
+            
             var data = serializer.Deserialize<DateTimeOffsetData>(reader);
 
             if (data == null)


### PR DESCRIPTION
Handles the backwards compatibility cause of data already stored as a Date BSON field.