### PR TITLE
fix: fix akavache build failing to sign

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,11 @@ pool:
   vmImage: vs2017-win2016
 
 steps:
+- task: DotNetCoreInstaller@0
+  displayName: Install Dot Net Core v2.2.1
+  inputs:
+    version: '2.2.103'
+    
 - task: BatchScript@1
   inputs:
     filename: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise\\Common7\\Tools\\VsDevCmd.bat"
@@ -21,8 +26,8 @@ steps:
   displayName: Build 
   env:
     COVERALLS_TOKEN: $(COVERALLS_TOKEN)
-    SignClientUser: $(SignClientUser)
-    SignClientSecret: $(SignClientSecret)
+    SIGNCLIENT_SECRET: $(SignClientSecret)
+    SIGNCLIENT_USER: $(SignClientUser)
     ArtifactDirectory: $(Build.ArtifactStagingDirectory)\Packages
 
 - task: CopyFiles@2


### PR DESCRIPTION
the name of the environment variables was different between rxui and akavache, now using the correct ones to match.