### PR TITLE
Fix datetime tick storage

### DIFF
--- a/src/Akavache.Core/JsonDateTimeTickConverter.cs
+++ b/src/Akavache.Core/JsonDateTimeTickConverter.cs
@@ -44,7 +44,7 @@ namespace Akavache
         {
             if (value is DateTime dateTime)
             {
-                serializer.Serialize(writer, dateTime.Ticks);
+                serializer.Serialize(writer, dateTime.ToUniversalTime().Ticks);
             }
         }
     }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fix bug where datetime is stored as local and restored as UTC forgetting the offset.

**What is the current behavior? (You can also link to an open issue here)**

stores 12:00 UTC+1
restores 12.00 UTC+0

**What is the new behavior (if this is a feature change)?**

stores 12:00 UTC+1
restores 11.00 UTC+0

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [X] The commit follows our guidelines: https://github.com/Akavache/Akavache/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

