### PR TITLE
fix infinite loop in new datetime converter, fixes issue #463

### DIFF
--- a/src/Akavache.Core/JsonDateTimeContractResolver.cs
+++ b/src/Akavache.Core/JsonDateTimeContractResolver.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json.Serialization;
 
 namespace Akavache
@@ -18,15 +16,20 @@ namespace Akavache
             existingContractResolver = contractResolver;
         }
 
-        protected override JsonContract CreateContract(Type objectType)
+        public override JsonContract ResolveContract(Type type)
         {
-            var contract = existingContractResolver?.ResolveContract(objectType) ?? base.CreateContract(objectType);
-            if (objectType == typeof(DateTime) || objectType == typeof(DateTime?))
+            var contract = existingContractResolver?.ResolveContract(type);
+            if (contract?.Converter != null)
+                return contract;
+
+            if (contract == null)
+                contract = base.ResolveContract(type);
+
+            if (type == typeof(DateTime) || type == typeof(DateTime?))
             {
                 contract.Converter = JsonDateTimeTickConverter.Default;
             }
-
-            if (objectType == typeof(DateTimeOffset) || objectType == typeof(DateTimeOffset?))
+            else if (type == typeof(DateTimeOffset) || type == typeof(DateTimeOffset?))
             {
                 contract.Converter = JsonDateTimeOffsetTickConverter.Default;
             }

--- a/src/Akavache.Tests/Akavache.Tests.csproj
+++ b/src/Akavache.Tests/Akavache.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="4.0.0" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="1.1.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Akavache.Tests/DateTimeTests.cs
+++ b/src/Akavache.Tests/DateTimeTests.cs
@@ -4,12 +4,83 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using Xunit;
 
 namespace Akavache.Tests
 {
     public class DateTimeTests
     {
+        public DateTimeTests()
+        {
+            SQLitePCL.Batteries_V2.Init();
+        }
+
+        [Fact]
+        public void JsonDateTimeContractResolver_ValidateConverter()
+        {
+            //Verify our converter used
+            var cr = (IContractResolver)new JsonDateTimeContractResolver(null);
+            var c = cr.ResolveContract(typeof(DateTime));
+            Assert.True(c.Converter == JsonDateTimeTickConverter.Default);
+            c = cr.ResolveContract(typeof(DateTime));
+            Assert.True(c.Converter == JsonDateTimeTickConverter.Default);
+            c = cr.ResolveContract(typeof(DateTime?));
+            Assert.True(c.Converter == JsonDateTimeTickConverter.Default);
+            c = cr.ResolveContract(typeof(DateTime?));
+            Assert.True(c.Converter == JsonDateTimeTickConverter.Default);
+
+            //Verify the other converter is used
+            cr = new JsonDateTimeContractResolver(new FakeDateTimeHighPrecisionContractResolver());
+            c = cr.ResolveContract(typeof(DateTime));
+            Assert.True(c.Converter is FakeDateTimeHighPrecisionJsonConverter);
+            c = cr.ResolveContract(typeof(DateTimeOffset));
+            Assert.True(c.Converter == JsonDateTimeOffsetTickConverter.Default);
+        }
+
+        class FakeDateTimeHighPrecisionContractResolver : DefaultContractResolver
+        {
+            protected override JsonContract CreateContract(Type objectType)
+            {
+                var contract = base.CreateContract(objectType);
+                if (objectType == typeof(DateTime) || objectType == typeof(DateTime?))
+                    contract.Converter = new FakeDateTimeHighPrecisionJsonConverter();
+                return contract;
+            }
+        }
+
+        class FakeDateTimeHighPrecisionJsonConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(DateTime) || objectType == typeof(DateTime?);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                if (reader.TokenType != JsonToken.Integer && reader.TokenType != JsonToken.Date)
+                    return null;
+
+                // If you need to deserialize already-serialized DateTimeOffsets, it would come in as JsonToken.Date, uncomment to handle
+                // Newly serialized values will come in as JsonToken.Integer
+                if (reader.TokenType == JsonToken.Date)
+                    return (DateTime)reader.Value;
+
+                var ticks = (long)reader.Value;
+                return new DateTime(ticks, DateTimeKind.Utc);
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                if (value != null) {
+                    var dateTime = value is DateTime dt ? dt : ((DateTime?)value).Value;
+                    serializer.Serialize(writer, dateTime.ToUniversalTime().Ticks);
+                }
+            }
+        }
+
+
         [Theory]
         [MemberData(nameof(DateTimeOffsetData))]
         public async Task GetOrFetchAsync_DateTimeOffsetShouldBeEqualEveryTime(TestObjectDateTimeOffset data)


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

fixes #463 

**What is the current behavior? (You can also link to an open issue here)**

The problem was that, as the default ResolveContract() calls CreateContact(), in your CreateContact() you can't call ResolveContract() on the embedded contractResolver, as it will also (often) inherit from DefaultContractResolver.

So it loops.

**What is the new behavior (if this is a feature change)?**

I moved the code in ResolveContract instead, which make the issue disappear. It won't loop anymore!

I also check if the contract is already overriden by the other resolver. In this case let it handle the conversion.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our guidelines: https://github.com/Akavache/Akavache/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

