### PR TITLE
turn off xunit shadowCopy

### DIFF
--- a/src/Akavache.Tests/Akavache.Tests.csproj
+++ b/src/Akavache.Tests/Akavache.Tests.csproj
@@ -24,4 +24,8 @@
     <ProjectReference Include="..\Akavache\Akavache.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/Akavache.Tests/xunit.runner.json
+++ b/src/Akavache.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+   "shadowCopy": false
+}
+


### PR DESCRIPTION

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This is a way to fix the problems with the xunit tests running under net461 with SQLitePCLRaw 2.0.

**What is the current behavior? (You can also link to an open issue here)**

An attempt to update the SQLitePCLRaw dependency to 2.0 caused problems with the xunit tests running under net461.  I've generally found xunit with .NET Framework to be problematic for SQLitePCLRaw.  Turning off shadowCopy has been an effective solution before.

See xunit/xunit#1198 for a bit more info.

**What is the new behavior (if this is a feature change)?**

The tests now run, on my machine anyway.

**Does this PR introduce a breaking change?**

I hope not.

**Please check if the PR fulfills these requirements**
- [I don't know ] The commit follows our guidelines: https://github.com/Akavache/Akavache/blob/master/CONTRIBUTING.md
- [Kinda ] Tests for the changes have been added (for bug fixes / features)
- [Not really ] Docs have been added / updated (for bug fixes / features)

**Other information**:

