### PR TITLE
housekeeping: Upgrade to Roslynator analyzers 2.2.0

### DIFF
--- a/src/Akavache.Sqlite3/Queues/OperationQueue.cs
+++ b/src/Akavache.Sqlite3/Queues/OperationQueue.cs
@@ -278,7 +278,7 @@ namespace Akavache.Sqlite3
 
                     try
                     {
-                        @lock = await lockTask;
+                        @lock = await lockTask.ConfigureAwait(false);
                     }
                     catch (OperationCanceledException)
                     {

--- a/src/Akavache.Sqlite3/SqlLiteCache/SqlRawPersistentBlobCache.cs
+++ b/src/Akavache.Sqlite3/SqlLiteCache/SqlRawPersistentBlobCache.cs
@@ -160,8 +160,8 @@ namespace Akavache.Sqlite3
                 .Select(x =>
                 {
                     var cacheElements = x.ToList();
-                    return cacheElements.Count() == 1
-                            ? (DateTimeOffset?)new DateTimeOffset(cacheElements.First().CreatedAt, TimeSpan.Zero)
+                    return cacheElements.Count == 1
+                            ? (DateTimeOffset?)new DateTimeOffset(cacheElements[0].CreatedAt, TimeSpan.Zero)
                             : default(DateTimeOffset?);
                 })
                 .PublishLast().PermaRef();

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="stylecop.analyzers" Version="1.1.118" PrivateAssets="all" />
-    <PackageReference Include="Roslynator.Analyzers" Version="2.1.0" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.7" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes the analyzers that fails and also upgrades Roslynator to 2.2.0