### PR TITLE
Fix Build/NuGet dependencies

### DIFF
--- a/src/Akavache.Core/Akavache.Core.csproj
+++ b/src/Akavache.Core/Akavache.Core.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="System.Reactive" Version="4.2.0" />
-    <PackageReference Include="Splat" Version="9.*" />
-    <PackageReference Include="Splat.Drawing" Version="9.*" />
+    <PackageReference Include="Splat" Version="9.3.11" />
+    <PackageReference Include="Splat.Drawing" Version="9.3.11" />
   </ItemGroup>
 
   <ItemGroup>
@@ -68,7 +68,7 @@
 
   <Target Name="_RemoveNonExistingResgenFile" BeforeTargets="CoreCompile" Condition="'$(_SdkSetAndroidResgenFile)' == 'true' And '$(AndroidResgenFile)' != '' And !Exists('$(AndroidResgenFile)')">
     <ItemGroup>
-      <Compile Remove="$(AndroidResgenFile)"/>
+      <Compile Remove="$(AndroidResgenFile)" />
     </ItemGroup>
   </Target>
 

--- a/src/Akavache.Sqlite3/Akavache.Sqlite3.csproj
+++ b/src/Akavache.Sqlite3/Akavache.Sqlite3.csproj
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="SQLitePCLRaw.core" Version="2.0.2" />
     <PackageReference Include="System.Reactive" Version="4.2.0" />
-    <PackageReference Include="Splat" Version="9.*" />
-    <PackageReference Include="Splat.Drawing" Version="9.*" />
+    <PackageReference Include="Splat" Version="9.3.11" />
+    <PackageReference Include="Splat.Drawing" Version="9.3.11" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
@@ -34,7 +34,7 @@
   
   <Target Name="_RemoveNonExistingResgenFile" BeforeTargets="CoreCompile" Condition="'$(_SdkSetAndroidResgenFile)' == 'true' And '$(AndroidResgenFile)' != '' And !Exists('$(AndroidResgenFile)')">
     <ItemGroup>
-      <Compile Remove="$(AndroidResgenFile)"/>
+      <Compile Remove="$(AndroidResgenFile)" />
     </ItemGroup>
   </Target>
 

--- a/src/Akavache.Tests/Akavache.Tests.csproj
+++ b/src/Akavache.Tests/Akavache.Tests.csproj
@@ -8,15 +8,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.3.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
     <PackageReference Include="Xunit.StaFact" Version="0.3.18" />
     <PackageReference Include="ReactiveUI.Testing" Version="10.*" />
-    <PackageReference Include="Splat" Version="9.*" />
-    <PackageReference Include="Splat.Drawing" Version="9.*" />
+    <PackageReference Include="Splat" Version="9.3.11" />
+    <PackageReference Include="Splat.Drawing" Version="9.3.11" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.2" />
     <PackageReference Include="Shouldly" Version="4.0.0-beta0002" />


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Fix the build.



**What is the current behaviour?**
The build is broken.



**What is the new behaviour?**
Build should work again.



**What might this PR break?**
The build might stay broken...


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other Information**:
The Splat packages were defined with 9.* which did not resolve to the latest package by default on Windows. This broke the local and Azure DevOps build.
