### PR TITLE
Release: Version 6.10 of Akavache

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.9",
+  "version": "6.10",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/develop$", // we release out of develop


### PR DESCRIPTION
Release version 6.10 of Akavache.

This release includes a new assembly called Akavache.Drawing which handles bitmap operations.

If you need to support Splat's IBitmap include a reference to this assembly.