### PR TITLE
Allow referencing Akavache.Drawing from NetStandard project

### DIFF
--- a/src/Akavache.Drawing/Akavache.Drawing.csproj
+++ b/src/Akavache.Drawing/Akavache.Drawing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;uap10.0.16299;netcoreapp3.0</TargetFrameworks>
     <AssemblyName>Akavache.Drawing</AssemblyName>
     <RootNamespace>Akavache</RootNamespace>

--- a/src/Akavache.Drawing/Registrations.cs
+++ b/src/Akavache.Drawing/Registrations.cs
@@ -23,7 +23,9 @@ namespace Akavache
                 throw new ArgumentNullException(nameof(resolver));
             }
 
+#if !NETSTANDARD
             Locator.CurrentMutable.RegisterPlatformBitmapLoader();
+#endif
         }
     }
 }

--- a/src/Akavache.sln
+++ b/src/Akavache.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akavache.Tests", "Akavache.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akavache", "Akavache\Akavache.csproj", "{506AB6E3-87E2-4D88-9C5C-07D24E590AAC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akavache.Drawing", "Akavache.Drawing\Akavache.Drawing.csproj", "{B24FE0E4-D602-45DC-8F3F-FE1C8F9AC63D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,14 @@ Global
 		{506AB6E3-87E2-4D88-9C5C-07D24E590AAC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{506AB6E3-87E2-4D88-9C5C-07D24E590AAC}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{506AB6E3-87E2-4D88-9C5C-07D24E590AAC}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B24FE0E4-D602-45DC-8F3F-FE1C8F9AC63D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B24FE0E4-D602-45DC-8F3F-FE1C8F9AC63D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B24FE0E4-D602-45DC-8F3F-FE1C8F9AC63D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B24FE0E4-D602-45DC-8F3F-FE1C8F9AC63D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B24FE0E4-D602-45DC-8F3F-FE1C8F9AC63D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B24FE0E4-D602-45DC-8F3F-FE1C8F9AC63D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B24FE0E4-D602-45DC-8F3F-FE1C8F9AC63D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B24FE0E4-D602-45DC-8F3F-FE1C8F9AC63D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Includes Akavache.Drawing in the .sln file
Adds netstandard2.0 the target frameworks for Akavache.Drawing


**What is the current behavior?**
After the bitmap mixing were moved to Akavache.Drawing, they could no longer be used in a .NET Standard project.

For example, on macOS, the following warning would be raised:

```
  [NU1701] Package 'Akavache.Drawing 6.10.2' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8' instead of the project target framework '.NETStandard,Version=v2.1'. This package may not be fully compatible with your project.
```


**What is the new behavior?**
Akavache.Drawing's targets include netstandard2.0. `Registrations` is still included, but does not call `RegisterPlatformBitmapLoader` when built for NetStandard.



**What might this PR break?**
The test pass rate is unchanged and the change is only to the newly separate Drawing project.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Not sure how to unit test something like this.

**Other information**:

