### PR TITLE
Fix: Don't create new ContractResolver on every serialization/deserialization

### DIFF
--- a/src/Akavache.Core/Json/JsonDateTimeContractResolver.cs
+++ b/src/Akavache.Core/Json/JsonDateTimeContractResolver.cs
@@ -14,8 +14,13 @@ namespace Akavache
     /// </summary>
     internal class JsonDateTimeContractResolver : DefaultContractResolver
     {
-        private readonly IContractResolver _existingContractResolver;
-        private readonly DateTimeKind? _forceDateTimeKindOverride;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonDateTimeContractResolver"/> class.
+        /// </summary>
+        public JsonDateTimeContractResolver()
+            : this(null, null)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonDateTimeContractResolver"/> class.
@@ -24,14 +29,18 @@ namespace Akavache
         /// <param name="forceDateTimeKindOverride">If we should override the <see cref="DateTimeKind"/>.</param>
         public JsonDateTimeContractResolver(IContractResolver contractResolver, DateTimeKind? forceDateTimeKindOverride)
         {
-            _existingContractResolver = contractResolver;
-            _forceDateTimeKindOverride = forceDateTimeKindOverride;
+            ExistingContractResolver = contractResolver;
+            ForceDateTimeKindOverride = forceDateTimeKindOverride;
         }
+
+        public IContractResolver ExistingContractResolver { get; set; }
+
+        public DateTimeKind? ForceDateTimeKindOverride { get; set; }
 
         /// <inheritdoc />
         public override JsonContract ResolveContract(Type type)
         {
-            var contract = _existingContractResolver?.ResolveContract(type);
+            var contract = ExistingContractResolver?.ResolveContract(type);
             if (contract?.Converter != null)
             {
                 return contract;
@@ -44,7 +53,7 @@ namespace Akavache
 
             if (type == typeof(DateTime) || type == typeof(DateTime?))
             {
-                contract.Converter = _forceDateTimeKindOverride == DateTimeKind.Local ? JsonDateTimeTickConverter.LocalDateTimeKindDefault : JsonDateTimeTickConverter.Default;
+                contract.Converter = ForceDateTimeKindOverride == DateTimeKind.Local ? JsonDateTimeTickConverter.LocalDateTimeKindDefault : JsonDateTimeTickConverter.Default;
             }
             else if (type == typeof(DateTimeOffset) || type == typeof(DateTimeOffset?))
             {

--- a/src/Akavache.Tests/TestBases/DateTimeTestBase.cs
+++ b/src/Akavache.Tests/TestBases/DateTimeTestBase.cs
@@ -17,11 +17,6 @@ namespace Akavache.Tests
     public abstract class DateTimeTestBase
     {
         /// <summary>
-        /// Time zone for when testing UTC vs local time operations. Just has to be something that doesn't match UTC.
-        /// </summary>
-        private const string TestTimeZone = "Pacific Standard Time";
-
-        /// <summary>
         /// Gets the date time offsets used in theory tests.
         /// </summary>
         public static IEnumerable<object[]> DateTimeOffsetData => new[]
@@ -56,7 +51,7 @@ namespace Akavache.Tests
         /// <summary>
         /// Gets the date time when the tests are done to keep them consistent.
         /// </summary>
-        private static DateTime LocalTestNow { get; } = TimeZoneInfo.ConvertTimeFromUtc(TestNow.ToUniversalTime(), TimeZoneInfo.FindSystemTimeZoneById(TestTimeZone));
+        private static DateTime LocalTestNow { get; } = TimeZoneInfo.ConvertTimeFromUtc(TestNow.ToUniversalTime(), TimeZoneInfo.CreateCustomTimeZone("testTimeZone", TimeSpan.FromHours(6), "Test Time Zone", "Test Time Zone"));
 
         /// <summary>
         /// Gets the date time off set when the tests are done to keep them consistent.

--- a/src/Akavache.Tests/UtilityTests.cs
+++ b/src/Akavache.Tests/UtilityTests.cs
@@ -52,12 +52,21 @@ namespace Akavache.Tests
         [Fact]
         public void UtilitySplitsAbsolutePaths()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            string path;
+            string expectedRoot;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return;
+                path = @"c:\foo\bar";
+                expectedRoot = @"c:\";
+            }
+            else
+            {
+                path = "/foo/bar";
+                expectedRoot = "/";
             }
 
-            Assert.Equal(new[] { @"c:\", "foo", "bar" }, new DirectoryInfo(@"c:\foo\bar").SplitFullPath());
+            Assert.Equal(new[] { expectedRoot, "foo", "bar" }, new DirectoryInfo(path).SplitFullPath());
         }
 
         /// <summary>
@@ -66,12 +75,18 @@ namespace Akavache.Tests
         [Fact]
         public void UtilityResolvesAndSplitsRelativePaths()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            string path;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return;
+                path = @"foo\bar";
+            }
+            else
+            {
+                path = "foo/bar";
             }
 
-            var components = new DirectoryInfo(@"foo\bar").SplitFullPath().ToList();
+            var components = new DirectoryInfo(path).SplitFullPath().ToList();
             Assert.True(components.Count > 2);
             Assert.Equal(new[] { "foo", "bar" }, components.Skip(components.Count - 2));
         }

--- a/src/Akavache.Tests/UtilityTests.cs
+++ b/src/Akavache.Tests/UtilityTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reactive.Subjects;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace Akavache.Tests
@@ -36,6 +37,11 @@ namespace Akavache.Tests
         [Fact]
         public void DirectoryCreateThrowsIOExceptionForNonexistentNetworkPaths()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             var exception = Assert.Throws<IOException>(() => new DirectoryInfo(@"\\does\not\exist").CreateRecursive());
             Assert.StartsWith("The network path was not found", exception.Message);
         }
@@ -46,6 +52,11 @@ namespace Akavache.Tests
         [Fact]
         public void UtilitySplitsAbsolutePaths()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             Assert.Equal(new[] { @"c:\", "foo", "bar" }, new DirectoryInfo(@"c:\foo\bar").SplitFullPath());
         }
 
@@ -55,6 +66,11 @@ namespace Akavache.Tests
         [Fact]
         public void UtilityResolvesAndSplitsRelativePaths()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             var components = new DirectoryInfo(@"foo\bar").SplitFullPath().ToList();
             Assert.True(components.Count > 2);
             Assert.Equal(new[] { "foo", "bar" }, components.Skip(components.Count - 2));
@@ -66,6 +82,11 @@ namespace Akavache.Tests
         [Fact]
         public void UtilitySplitsUncPaths()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             Assert.Equal(new[] { @"\\foo\bar", "baz" }, new DirectoryInfo(@"\\foo\bar\baz").SplitFullPath());
         }
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix: #587 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->
For every single object that is serialized/deserialized, a new ContractResolver is created. This is a VERY expensive, reflection-heavy operation. Newtonsoft.Json is very clear that you should create and reuse a single ContractResolver.

**What is the new behavior?**
<!-- If this is a feature change -->

**What might this PR break?**
I believe this is low-risk.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
If anyone has an idea of how to test this, please let me know. It is an implementation detail of a private method. As a part of this, I also fixed a couple tests that didn't work on unix-based systems.

Note that this improves performance of bulk operations by up to 40x on my Mac, iOS, and Android devices.