### PR TITLE
Add AOT markup

### DIFF
--- a/src/Akavache.Core/BlobCache/BlobCache.cs
+++ b/src/Akavache.Core/BlobCache/BlobCache.cs
@@ -13,6 +13,10 @@ namespace Akavache;
 /// <summary>
 /// A class which represents a blobbed cache.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Core")]
+[RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
 public static class BlobCache
 {
     private static string? _applicationName;
@@ -34,7 +38,7 @@ public static class BlobCache
 
     static BlobCache()
     {
-        Locator.RegisterResolverCallbackChanged(() =>
+        Locator.RegisterResolverCallbackChanged(static () =>
         {
             if (Locator.CurrentMutable is null)
             {

--- a/src/Akavache.Core/BlobCache/InMemoryBlobCache.cs
+++ b/src/Akavache.Core/BlobCache/InMemoryBlobCache.cs
@@ -15,6 +15,10 @@ namespace Akavache;
 /// This class is an IBlobCache backed by a simple in-memory Dictionary.
 /// Use it for testing / mocking purposes.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Core")]
+[RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
 public class InMemoryBlobCache : ISecureBlobCache, IObjectBlobCache, IEnableLogger
 {
     [SuppressMessage("Design", "CA2213: non-disposed field.", Justification = "Used for notification of dispose.")]

--- a/src/Akavache.Core/DependencyResolverMixin.cs
+++ b/src/Akavache.Core/DependencyResolverMixin.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 using Splat;
@@ -12,6 +13,10 @@ namespace Akavache;
 /// <summary>
 /// A set of mix-in associated with the <see cref="IDependencyResolver"/> interface.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Core")]
+[RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
 public static class DependencyResolverMixin
 {
     /// <summary>

--- a/src/Akavache.Core/IWantsToRegisterStuff.cs
+++ b/src/Akavache.Core/IWantsToRegisterStuff.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Splat;
 
 namespace Akavache;

--- a/src/Akavache.Core/KeyedOperations/KeyedOperationQueue.cs
+++ b/src/Akavache.Core/KeyedOperations/KeyedOperationQueue.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Splat;
 
@@ -11,6 +12,10 @@ namespace Akavache;
 /// <summary>
 /// A key which has separate buckets for each key.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Core")]
+[RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
 public class KeyedOperationQueue : IKeyedOperationQueue, IEnableLogger, IDisposable
 {
     private static int _sequenceNumber = 1;

--- a/src/Akavache.Core/Platforms/android/AndroidFilesystemProvider.cs
+++ b/src/Akavache.Core/Platforms/android/AndroidFilesystemProvider.cs
@@ -7,21 +7,27 @@
 using Android.App;
 #endif
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Akavache;
 
 /// <summary>
 /// The file system provider that understands the android.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Core")]
+[RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
 public class AndroidFilesystemProvider : IFilesystemProvider
 {
     private readonly SimpleFilesystemProvider _inner = new();
 
     /// <inheritdoc />
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
     public IObservable<Stream> OpenFileForReadAsync(string path, IScheduler scheduler) => _inner.OpenFileForReadAsync(path, scheduler);
 
     /// <inheritdoc />
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
     public IObservable<Stream> OpenFileForWriteAsync(string path, IScheduler scheduler) => _inner.OpenFileForWriteAsync(path, scheduler);
 
     /// <inheritdoc />

--- a/src/Akavache.Core/Platforms/apple-common/MacFilesystemProvider.cs
+++ b/src/Akavache.Core/Platforms/apple-common/MacFilesystemProvider.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Foundation;
 
 namespace Akavache;
@@ -10,16 +11,20 @@ namespace Akavache;
 /// <summary>
 /// A file system provider that is related to the Mac operating system.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Core")]
+[RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
 public class MacFilesystemProvider : IFilesystemProvider
 {
     private readonly SimpleFilesystemProvider _inner = new();
 
     /// <inheritdoc />
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
     public IObservable<Stream> OpenFileForReadAsync(string path, IScheduler scheduler) => _inner.OpenFileForReadAsync(path, scheduler);
 
     /// <inheritdoc />
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
     public IObservable<Stream> OpenFileForWriteAsync(string path, IScheduler scheduler) => _inner.OpenFileForWriteAsync(path, scheduler);
 
     /// <inheritdoc />

--- a/src/Akavache.Core/Platforms/shared-not-uwp/SimpleFilesystemProvider.cs
+++ b/src/Akavache.Core/Platforms/shared-not-uwp/SimpleFilesystemProvider.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Splat;
 
@@ -11,14 +12,18 @@ namespace Akavache;
 /// <summary>
 /// A wrapper around the file system.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Core")]
+[RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
 public class SimpleFilesystemProvider : IFilesystemProvider
 {
     /// <inheritdoc />
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
     public IObservable<Stream> OpenFileForReadAsync(string path, IScheduler scheduler) => Utility.SafeOpenFileAsync(path, FileMode.Open, FileAccess.Read, FileShare.Read, scheduler);
 
     /// <inheritdoc />
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
     public IObservable<Stream> OpenFileForWriteAsync(string path, IScheduler scheduler) => Utility.SafeOpenFileAsync(path, FileMode.Create, FileAccess.Write, FileShare.None, scheduler);
 
     /// <inheritdoc />
@@ -55,7 +60,7 @@ public class SimpleFilesystemProvider : IFilesystemProvider
     /// <returns>The assembly directory name.</returns>
     protected static string GetAssemblyDirectoryName()
     {
-        var assemblyDirectoryName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        var assemblyDirectoryName = Path.GetDirectoryName(AppContext.BaseDirectory);
 
         return assemblyDirectoryName ?? throw new InvalidOperationException("The directory name of the assembly location is null");
     }

--- a/src/Akavache.Core/Platforms/shared/AkavacheHttpMixin.cs
+++ b/src/Akavache.Core/Platforms/shared/AkavacheHttpMixin.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Splat;
 
 namespace Akavache;
@@ -10,6 +11,10 @@ namespace Akavache;
 /// <summary>
 /// A set of methods associated with accessing HTTP resources for a blob cache.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Core")]
+[RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
 public class AkavacheHttpMixin : IAkavacheHttpMixin
 {
     private static IAkavacheHttpClientFactory HttpFactoryClient => Locator.Current.GetService<IAkavacheHttpClientFactory>() ?? throw new InvalidOperationException("Unable to resolve IAkavacheHttpClientFactory, probably Akavache is not initialized.");

--- a/src/Akavache.Core/Platforms/shared/Registrations.cs
+++ b/src/Akavache.Core/Platforms/shared/Registrations.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Splat;
 
 #if COCOA
@@ -22,6 +23,10 @@ namespace Akavache.Core
     /// Performs registration inside the Splat DI container.
     /// </summary>
     [Preserve(AllMembers = true)]
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode("Registrations for Akavache.Core")]
+    [RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
     public class Registrations : IWantsToRegisterStuff
     {
         /// <inheritdoc />

--- a/src/Akavache.Core/Platforms/shared/Utility.cs
+++ b/src/Akavache.Core/Platforms/shared/Utility.cs
@@ -10,6 +10,10 @@ using Splat;
 namespace Akavache;
 
 [SuppressMessage("FxCop.Style", "CA5351: GetMd5Hash uses a broken cryptographic algorithm MD5", Justification = "Not used for encryption.")]
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Core")]
+[RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
 internal static partial class Utility
 {
     public static string GetMd5Hash(string input)

--- a/src/Akavache.Core/Platforms/xamarin-mobile/IsolatedStorageProvider.cs
+++ b/src/Akavache.Core/Platforms/xamarin-mobile/IsolatedStorageProvider.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.IO.IsolatedStorage;
 using System.Reactive.Disposables;
 
@@ -11,6 +12,10 @@ namespace Akavache;
 /// <summary>
 /// A storage provided that uses isolated storage.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Core")]
+[RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
 public class IsolatedStorageProvider : IFilesystemProvider
 {
     /// <inheritdoc />
@@ -35,7 +40,7 @@ public class IsolatedStorageProvider : IFilesystemProvider
         });
 
     /// <inheritdoc />
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design")]
     public IObservable<Stream> OpenFileForWriteAsync(string path, IScheduler scheduler) =>
         Observable.Create<Stream>(subj =>
         {

--- a/src/Akavache.Core/Providers/IFilesystemProvider.cs
+++ b/src/Akavache.Core/Providers/IFilesystemProvider.cs
@@ -3,6 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Akavache;
 
 /// <summary>
@@ -46,6 +48,10 @@ public interface IFilesystemProvider
     /// </summary>
     /// <param name="path">The path to the file.</param>
     /// <returns>A observable which signals when the delete is finished.</returns>
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode("Registrations for Akavache.Core")]
+    [RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
     IObservable<Unit> Delete(string path);
 
     /// <summary>

--- a/src/Akavache.Drawing/Registrations.cs
+++ b/src/Akavache.Drawing/Registrations.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Akavache.Core;
 using Splat;
 
@@ -12,6 +13,10 @@ namespace Akavache.Drawing;
 /// Setup registrations for the application.
 /// </summary>
 [Preserve(AllMembers = true)]
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Drawing")]
+[RequiresDynamicCode("Registrations for Akavache.Drawing")]
+#endif
 public class Registrations : IWantsToRegisterStuff
 {
     /// <inheritdoc />

--- a/src/Akavache.Mobile/AkavacheDriver.cs
+++ b/src/Akavache.Mobile/AkavacheDriver.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using ReactiveUI;
 
 using Splat;
@@ -12,6 +13,10 @@ namespace Akavache.Mobile;
 /// <summary>
 /// The main driver for a mobile application. Used primary by the ReactiveUI project.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Mobile")]
+[RequiresDynamicCode("Registrations for Akavache.Mobile")]
+#endif
 public class AkavacheDriver : ISuspensionDriver, IEnableLogger
 {
     /// <inheritdoc />

--- a/src/Akavache.Mobile/Registrations.cs
+++ b/src/Akavache.Mobile/Registrations.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Akavache.Core;
 using Newtonsoft.Json;
 using ReactiveUI;
@@ -14,6 +15,10 @@ namespace Akavache.Mobile;
 /// Registrations for the mobile platform. Will register all our instances with splat.
 /// </summary>
 [Preserve(AllMembers = true)]
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Mobile")]
+[RequiresDynamicCode("Registrations for Akavache.Mobile")]
+#endif
 public class Registrations : IWantsToRegisterStuff
 {
     /// <inheritdoc />

--- a/src/Akavache.Sqlite3/Registrations.cs
+++ b/src/Akavache.Sqlite3/Registrations.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Akavache.Core;
 
 using Splat;
@@ -13,6 +14,10 @@ namespace Akavache.Sqlite3;
 /// Adds registrations required for the SQLite3 integration.
 /// </summary>
 [Preserve(AllMembers = true)]
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Sqlite3")]
+[RequiresDynamicCode("Registrations for Akavache.Sqlite3")]
+#endif
 public class Registrations : IWantsToRegisterStuff
 {
     /// <summary>

--- a/src/Akavache.Sqlite3/SqlLiteCache/SQLiteEncryptedBlobCache.cs
+++ b/src/Akavache.Sqlite3/SqlLiteCache/SQLiteEncryptedBlobCache.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Splat;
 
 namespace Akavache.Sqlite3;
@@ -10,6 +11,10 @@ namespace Akavache.Sqlite3;
 /// <summary>
 /// A SQLite blob cache where all the entries are encrypted.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Core")]
+[RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
 public class SQLiteEncryptedBlobCache : SqlRawPersistentBlobCache, ISecureBlobCache
 {
     private readonly IEncryptionProvider _encryption;

--- a/src/Akavache.Sqlite3/SqlLiteCache/SqlRawPersistentBlobCache.cs
+++ b/src/Akavache.Sqlite3/SqlLiteCache/SqlRawPersistentBlobCache.cs
@@ -19,6 +19,10 @@ namespace Akavache.Sqlite3;
 /// This class represents an IBlobCache backed by a SQLite3 database, and
 /// it is the default (and best!) implementation.
 /// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache.Core")]
+[RequiresDynamicCode("Registrations for Akavache.Core")]
+#endif
 public class SqlRawPersistentBlobCache : IEnableLogger, IObjectBulkBlobCache
 {
     private static readonly object DisposeGate = 42;

--- a/src/Akavache.Tests/API/ApiApprovalTests.AkavacheCore.DotNet8_0.verified.txt
+++ b/src/Akavache.Tests/API/ApiApprovalTests.AkavacheCore.DotNet8_0.verified.txt
@@ -6,6 +6,8 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace Akavache
 {
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public class AkavacheHttpMixin : Akavache.IAkavacheHttpMixin
     {
         public AkavacheHttpMixin() { }
@@ -18,6 +20,8 @@ namespace Akavache
         public System.IObservable<byte[]> DownloadUrl(Akavache.IBlobCache blobCache, System.Net.Http.HttpMethod method, string key, string url, System.Collections.Generic.IDictionary<string, string>? headers = null, bool fetchAlways = false, System.DateTimeOffset? absoluteExpiration = default) { }
         public System.IObservable<byte[]> DownloadUrl(Akavache.IBlobCache blobCache, System.Net.Http.HttpMethod method, string key, System.Uri url, System.Collections.Generic.IDictionary<string, string>? headers = null, bool fetchAlways = false, System.DateTimeOffset? absoluteExpiration = default) { }
     }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public static class BlobCache
     {
         public static string ApplicationName { get; set; }
@@ -57,6 +61,8 @@ namespace Akavache
         public DefaultAkavacheHttpClientFactory() { }
         public System.Net.Http.HttpClient CreateClient(string name) { }
     }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public static class DependencyResolverMixin
     {
         public static void InitializeAkavache(this Splat.IMutableDependencyResolver resolver, Splat.IReadonlyDependencyResolver readonlyDependencyResolver) { }
@@ -122,6 +128,8 @@ namespace Akavache
     public interface IFilesystemProvider
     {
         System.IObservable<System.Reactive.Unit> CreateRecursive(string path);
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
         System.IObservable<System.Reactive.Unit> Delete(string path);
         string? GetDefaultLocalMachineCacheDirectory();
         string? GetDefaultRoamingCacheDirectory();
@@ -152,6 +160,8 @@ namespace Akavache
         System.IObservable<System.Reactive.Unit> InvalidateObjects<T>(System.Collections.Generic.IEnumerable<string> keys);
     }
     public interface ISecureBlobCache : Akavache.IBlobCache, System.IDisposable { }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public class InMemoryBlobCache : Akavache.IBlobCache, Akavache.IObjectBlobCache, Akavache.ISecureBlobCache, Splat.IEnableLogger, System.IDisposable
     {
         public InMemoryBlobCache() { }
@@ -196,6 +206,8 @@ namespace Akavache
         public static System.IObservable<System.Reactive.Unit> InvalidateAllObjects<T>(this Akavache.IBlobCache blobCache) { }
         public static System.IObservable<System.Reactive.Unit> InvalidateObject<T>(this Akavache.IBlobCache blobCache, string key) { }
     }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public class KeyedOperationQueue : Akavache.IKeyedOperationQueue, Splat.IEnableLogger, System.IDisposable
     {
         public KeyedOperationQueue(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
@@ -231,6 +243,8 @@ namespace Akavache
         public static System.IObservable<System.Reactive.Unit> InsertObject<T>(this Akavache.IBlobCache blobCache, string key, T value, System.TimeSpan expiration) { }
         public static System.IObservable<System.Reactive.Unit> SaveLogin(this Akavache.ISecureBlobCache blobCache, string user, string password, string host, System.TimeSpan expiration) { }
     }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public class SimpleFilesystemProvider : Akavache.IFilesystemProvider
     {
         public SimpleFilesystemProvider() { }
@@ -246,6 +260,8 @@ namespace Akavache
 }
 namespace Akavache.Core
 {
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public class Registrations
     {
         public Registrations() { }

--- a/src/Akavache.Tests/API/ApiApprovalTests.AkavacheDrawing.DotNet8_0.verified.txt
+++ b/src/Akavache.Tests/API/ApiApprovalTests.AkavacheDrawing.DotNet8_0.verified.txt
@@ -13,6 +13,8 @@ namespace Akavache
 }
 namespace Akavache.Drawing
 {
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Drawing")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Drawing")]
     public class Registrations
     {
         public Registrations() { }

--- a/src/Akavache.Tests/API/ApiApprovalTests.AkavacheProject.DotNet8_0.verified.txt
+++ b/src/Akavache.Tests/API/ApiApprovalTests.AkavacheProject.DotNet8_0.verified.txt
@@ -1,6 +1,8 @@
 ﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace Akavache
 {
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache")]
     public class Registrations
     {
         public Registrations() { }
@@ -11,6 +13,8 @@ namespace Akavache
 namespace Akavache.Sqlite3
 {
     public static class LinkerPreserve { }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache")]
     public class SQLitePersistentBlobCache : Akavache.Sqlite3.SqlRawPersistentBlobCache
     {
         public SQLitePersistentBlobCache(string databaseFile, System.Reactive.Concurrency.IScheduler? scheduler = null) { }

--- a/src/Akavache.Tests/AsyncLockTests.cs
+++ b/src/Akavache.Tests/AsyncLockTests.cs
@@ -26,6 +26,7 @@ public class AsyncLockTests
 
         Assert.True(lockOne.IsCompleted);
         Assert.Equal(TaskStatus.RanToCompletion, lockOne.Status);
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
         Assert.NotNull(lockOne.Result);
 
         Assert.False(lockTwo.IsCompleted);
@@ -36,5 +37,6 @@ public class AsyncLockTests
         Assert.True(lockTwo.IsCanceled);
 
         lockOne.Result.Dispose();
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
     }
 }

--- a/src/Akavache.Tests/CoalescerTests.cs
+++ b/src/Akavache.Tests/CoalescerTests.cs
@@ -24,7 +24,7 @@ public class CoalescerTests
     public async Task SingleItem()
     {
         var fixture = new SqliteOperationQueue();
-        fixture.Select(new[] { "Foo" });
+        fixture.Select(["Foo"]);
 
         var queue = fixture.DumpQueue();
         var subj = queue[0].CompletionAsElements;
@@ -40,9 +40,9 @@ public class CoalescerTests
         var outSub = result[0].CompletionAsElements;
 
         Assert.Equal(0, output.Count);
-        outSub.OnNext(new[] { new CacheElement { Key = "Foo" } });
+        outSub.OnNext([new CacheElement { Key = "Foo" }]);
         outSub.OnCompleted();
-        await Task.Delay(500).ConfigureAwait(false);
+        await Task.Delay(500);
         Assert.Equal(1, output.Count);
     }
 
@@ -54,9 +54,9 @@ public class CoalescerTests
     public async Task UnrelatedItems()
     {
         var fixture = new SqliteOperationQueue();
-        fixture.Select(new[] { "Foo" });
-        fixture.Insert(new[] { new CacheElement { Key = "Bar" } });
-        fixture.Invalidate(new[] { "Baz" });
+        fixture.Select(["Foo"]);
+        fixture.Insert([new CacheElement { Key = "Bar" }]);
+        fixture.Invalidate(["Baz"]);
 
         var queue = fixture.DumpQueue();
         var subj = queue[0].CompletionAsElements;
@@ -72,9 +72,9 @@ public class CoalescerTests
         var outSub = result[0].CompletionAsElements;
 
         Assert.Equal(0, output.Count);
-        outSub.OnNext(new[] { new CacheElement { Key = "Foo" } });
+        outSub.OnNext([new CacheElement { Key = "Foo" }]);
         outSub.OnCompleted();
-        await Task.Delay(500).ConfigureAwait(false);
+        await Task.Delay(500);
         Assert.Equal(1, output.Count);
     }
 
@@ -87,10 +87,10 @@ public class CoalescerTests
     {
         var fixture = new SqliteOperationQueue();
 
-        fixture.Select(new[] { "Foo" });
-        fixture.Select(new[] { "Bar" });
-        fixture.Invalidate(new[] { "Bamf" });
-        fixture.Select(new[] { "Baz" });
+        fixture.Select(["Foo"]);
+        fixture.Select(["Bar"]);
+        fixture.Invalidate(["Bamf"]);
+        fixture.Select(["Baz"]);
 
         var queue = fixture.DumpQueue();
         queue.Where(x => x.OperationType == OperationType.BulkSelectSqliteOperation)
@@ -120,7 +120,7 @@ public class CoalescerTests
         Assert.Equal(0, output.Count);
         outSub.OnNext(fakeResult);
         outSub.OnCompleted();
-        await Task.Delay(1000).ConfigureAwait(false);
+        await Task.Delay(1000);
         Assert.Equal(3, output.Count);
     }
 
@@ -132,10 +132,10 @@ public class CoalescerTests
     public async Task DedupRelatedSelects()
     {
         var fixture = new SqliteOperationQueue();
-        fixture.Select(new[] { "Foo" });
-        fixture.Select(new[] { "Foo" });
-        fixture.Select(new[] { "Bar" });
-        fixture.Select(new[] { "Foo" });
+        fixture.Select(["Foo"]);
+        fixture.Select(["Foo"]);
+        fixture.Select(["Bar"]);
+        fixture.Select(["Foo"]);
 
         var queue = fixture.DumpQueue();
         queue.Where(x => x.OperationType == OperationType.BulkSelectSqliteOperation)
@@ -161,7 +161,7 @@ public class CoalescerTests
         Assert.Equal(0, output.Count);
         outSub.OnNext(fakeResult);
         outSub.OnCompleted();
-        await Task.Delay(1000).ConfigureAwait(false);
+        await Task.Delay(1000);
         Assert.Equal(4, output.Count);
     }
 
@@ -172,10 +172,10 @@ public class CoalescerTests
     public void InterpolatedOpsDontGetDeduped()
     {
         var fixture = new SqliteOperationQueue();
-        fixture.Select(new[] { "Foo" });
-        fixture.Insert(new[] { new CacheElement { Key = "Foo", Value = [1, 2, 3] } });
-        fixture.Select(new[] { "Foo" });
-        fixture.Insert(new[] { new CacheElement { Key = "Foo", Value = [4, 5, 6] } });
+        fixture.Select(["Foo"]);
+        fixture.Insert([new CacheElement { Key = "Foo", Value = [1, 2, 3] }]);
+        fixture.Select(["Foo"]);
+        fixture.Insert([new CacheElement { Key = "Foo", Value = [4, 5, 6] }]);
 
         var queue = fixture.DumpQueue();
         var result = SqliteOperationQueue.CoalesceOperations(queue);
@@ -201,8 +201,8 @@ public class CoalescerTests
         using (var cache = new SQLitePersistentBlobCache(Path.Combine(path, "sqlite.db")))
         {
             var queue = new SqliteOperationQueue(cache.Connection, BlobCache.TaskpoolScheduler);
-            var request = queue.Select(new[] { "Foo" });
-            var unrelatedRequest = queue.Select(new[] { "Bar" });
+            var request = queue.Select(["Foo"]);
+            var unrelatedRequest = queue.Select(["Bar"]);
 
             cache.ReplaceOperationQueue(queue);
 

--- a/src/Akavache.Tests/TestBases/BulkOperationsTestBase.cs
+++ b/src/Akavache.Tests/TestBases/BulkOperationsTestBase.cs
@@ -23,7 +23,7 @@ public abstract class BulkOperationsTestBase
             var data = new byte[] { 0x10, 0x20, 0x30, };
             var keys = new[] { "Foo", "Bar", "Baz", };
 
-            await Task.WhenAll(keys.Select(async v => await fixture.Insert(v, data).FirstAsync())).ConfigureAwait(false);
+            await Task.WhenAll(keys.Select(async v => await fixture.Insert(v, data).FirstAsync()));
 
             Assert.Equal(keys.Length, (await fixture.GetAllKeys().FirstAsync()).Count());
 
@@ -47,7 +47,7 @@ public abstract class BulkOperationsTestBase
             var data = new byte[] { 0x10, 0x20, 0x30, };
             var keys = new[] { "Foo", "Bar", "Baz", };
 
-            await Task.WhenAll(keys.Select(async v => await fixture.Insert(v, data, DateTimeOffset.MinValue).FirstAsync())).ConfigureAwait(false);
+            await Task.WhenAll(keys.Select(async v => await fixture.Insert(v, data, DateTimeOffset.MinValue).FirstAsync()));
 
             var allData = await fixture.Get(keys).FirstAsync();
             Assert.Equal(0, allData.Count);
@@ -92,7 +92,7 @@ public abstract class BulkOperationsTestBase
             var data = new byte[] { 0x10, 0x20, 0x30, };
             var keys = new[] { "Foo", "Bar", "Baz", };
 
-            await Task.WhenAll(keys.Select(async v => await fixture.Insert(v, data).FirstAsync())).ConfigureAwait(false);
+            await Task.WhenAll(keys.Select(async v => await fixture.Insert(v, data).FirstAsync()));
 
             Assert.Equal(keys.Length, (await fixture.GetAllKeys().FirstAsync()).Count());
 

--- a/src/Akavache/Registrations.cs
+++ b/src/Akavache/Registrations.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Akavache.Core;
 using Splat;
 
@@ -12,6 +13,10 @@ namespace Akavache;
 /// Setup registrations for the application.
 /// </summary>
 [Preserve(AllMembers = true)]
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache")]
+[RequiresDynamicCode("Registrations for Akavache")]
+#endif
 public class Registrations : IWantsToRegisterStuff
 {
     /// <summary>

--- a/src/Akavache/SQLitePersistentBlobCache.cs
+++ b/src/Akavache/SQLitePersistentBlobCache.cs
@@ -3,6 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Akavache.Sqlite3;
 
 /// <summary>
@@ -21,4 +23,8 @@ namespace Akavache.Sqlite3;
 /// </remarks>
 /// <param name="databaseFile">The location of the database file which to store the blobs in.</param>
 /// <param name="scheduler">Scheduler to use for contained observables.</param>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Registrations for Akavache")]
+[RequiresDynamicCode("Registrations for Akavache")]
+#endif
 public class SQLitePersistentBlobCache(string databaseFile, IScheduler? scheduler = null) : SqlRawPersistentBlobCache(databaseFile, scheduler);

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -31,6 +31,9 @@
     <AkavacheTargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net8.0-android;net8.0-ios;net8.0-tvos;net8.0-macos;net8.0-maccatalyst</AkavacheTargetFrameworks>
     <!--<AkavacheTargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(AkavacheTargetFrameworks);net462</AkavacheTargetFrameworks>-->
   </PropertyGroup>
+  <PropertyGroup Condition="'$(IsTestProject)' != 'true' and ($(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')))">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
 
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\LICENSE" Pack="true" PackagePath="LICENSE" />


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

no AOT markup present

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request includes various changes to the `Akavache` project, primarily to add attributes for handling code analysis warnings and to update method implementations. The most important changes are grouped by theme below.

### Code Analysis and Attribute Additions:

* Added `RequiresUnreferencedCode` and `RequiresDynamicCode` attributes for .NET 8.0 or greater in multiple files, including `BlobCache.cs`, `InMemoryBlobCache.cs`, `DependencyResolverMixin.cs`, `KeyedOperationQueue.cs`, `AndroidFilesystemProvider.cs`, `MacFilesystemProvider.cs`, `SimpleFilesystemProvider.cs`, `AkavacheHttpMixin.cs`, `Registrations.cs`, `Utility.cs`, `IsolatedStorageProvider.cs`, `IFilesystemProvider.cs`, `AkavacheDriver.cs`, and `Registrations.cs` in various namespaces. [[1]](diffhunk://#diff-601d200b0f55ce7dca8675336794630ac65202b449dec95c308ffbba70cb996bR16-R19) [[2]](diffhunk://#diff-142259ed3536633990bd02d09821680b0e5ee1582edc53559414bde54cc66439R18-R21) [[3]](diffhunk://#diff-68cb985e959fdff17778280ca0bb937bb43b6544ff481b531be47b89c65a1f03R16-R19) [[4]](diffhunk://#diff-3de7549a3e9bf202fec8bdf26cf94d6629097775332d23419915f43f8f930869R15-R18) [[5]](diffhunk://#diff-36f1320e637e001896b77fedc8dcf9227fb77b2b8e5280a21b2fccac74359b20R10-R30) [[6]](diffhunk://#diff-1e89990462e71ccda571e8273f8652c952ce96f51d1b89420acf7ec9e87ac98dR6-R27) [[7]](diffhunk://#diff-8a478bec92cc3d7792812ffd33b72005930caa6908bf5bcd582524931d84f917R15-R26) [[8]](diffhunk://#diff-003e0714eec1c52f7a85fe61438f286edd568726eda578efd2f868f2cebe922cR6-R17) [[9]](diffhunk://#diff-1cc0b25a15c910ac37777641cbe24f40085dbccb726c16205b66d366d811f3b7R26-R29) [[10]](diffhunk://#diff-3d83646a11a52df205a9e058ad6fc180914ee84615b6e17949ce67e4ffe58f0bR13-R16) [[11]](diffhunk://#diff-5d273bb2b182183c139f7e1f6cb0a026fc932c94a36b6b447cf747c3e04f60bfR15-R18) [[12]](diffhunk://#diff-72a1531d5c0496ff559cc286505ab1e150501dea12f6988fa573100d2dabbfe6R51-R54) [[13]](diffhunk://#diff-5da5425fbba08e4b3b7b3f3290504686f98080e3e74ebe97e131fe5fbc721b44R16-R19) [[14]](diffhunk://#diff-db63fd40800c8ad9967d40e5c8d72effdf48fce2a699c95c70d8d4d9653c9756R16-R19) [[15]](diffhunk://#diff-7832fba97de52aa2cb536485d675eab2455aa1bab8050d57e5b6a065829f051eR18-R21) [[16]](diffhunk://#diff-b3364165876deb71088ec707a4df02ce45bf5e81eef5143ff3382358013d0194R17-R20)

### Code Simplification and Refactoring:

* Updated method registration in `BlobCache.cs` to use a static lambda expression.
* Replaced `Assembly.GetExecutingAssembly().Location` with `AppContext.BaseDirectory` in `SimpleFilesystemProvider.cs` to get the assembly directory name.

### SuppressMessage Attribute Adjustments:

* Simplified the `SuppressMessage` attributes by removing the namespace prefix in multiple files such as `AndroidFilesystemProvider.cs`, `MacFilesystemProvider.cs`, `SimpleFilesystemProvider.cs`, and `IsolatedStorageProvider.cs`. (F36a38d5L35R40, Fa40a195L35R40, F73a5004L35R40, [src/Akavache.Core/Platforms/xamarin-mobile/IsolatedStorageProvider.csL38-R43](diffhunk://#diff-5d273bb2b182183c139f7e1f6cb0a026fc932c94a36b6b447cf747c3e04f60bfL38-R43))

### Additional Usings:

* Added `System.Diagnostics.CodeAnalysis` using directive in multiple files to support the new attributes. [[1]](diffhunk://#diff-68cb985e959fdff17778280ca0bb937bb43b6544ff481b531be47b89c65a1f03R6) [[2]](diffhunk://#diff-3073213643bfdeecce82bda8cadc029b8127a55d0e125383a3351d1e1ae096daR6) [[3]](diffhunk://#diff-3de7549a3e9bf202fec8bdf26cf94d6629097775332d23419915f43f8f930869R6) F36a38d5L3R3, [[4]](diffhunk://#diff-1e89990462e71ccda571e8273f8652c952ce96f51d1b89420acf7ec9e87ac98dR6-R27) [[5]](diffhunk://#diff-8a478bec92cc3d7792812ffd33b72005930caa6908bf5bcd582524931d84f917R6) [[6]](diffhunk://#diff-003e0714eec1c52f7a85fe61438f286edd568726eda578efd2f868f2cebe922cR6-R17) [[7]](diffhunk://#diff-1cc0b25a15c910ac37777641cbe24f40085dbccb726c16205b66d366d811f3b7R6) [[8]](diffhunk://#diff-5d273bb2b182183c139f7e1f6cb0a026fc932c94a36b6b447cf747c3e04f60bfR6) [[9]](diffhunk://#diff-72a1531d5c0496ff559cc286505ab1e150501dea12f6988fa573100d2dabbfe6R6-R7) [[10]](diffhunk://#diff-5da5425fbba08e4b3b7b3f3290504686f98080e3e74ebe97e131fe5fbc721b44R6) [[11]](diffhunk://#diff-db63fd40800c8ad9967d40e5c8d72effdf48fce2a699c95c70d8d4d9653c9756R6) [[12]](diffhunk://#diff-7832fba97de52aa2cb536485d675eab2455aa1bab8050d57e5b6a065829f051eR6) [[13]](diffhunk://#diff-b3364165876deb71088ec707a4df02ce45bf5e81eef5143ff3382358013d0194R6)

**What might this PR break?**

AOT Warnings will be present on consumer's projects

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

