### PR TITLE
Housekeeping Update packages after breaking change

### DIFF
--- a/src/Akavache.Core/Akavache.Core.csproj
+++ b/src/Akavache.Core/Akavache.Core.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="Splat" Version="15.3.1" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.3" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.3" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.6" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Akavache.Drawing/Akavache.Drawing.csproj
+++ b/src/Akavache.Drawing/Akavache.Drawing.csproj
@@ -15,6 +15,6 @@
   
   <ItemGroup>
     <PackageReference Include="Splat.Drawing" Version="15.3.1" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.3" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.6" />
   </ItemGroup>
 </Project>

--- a/src/Akavache.Mobile/Akavache.Mobile.csproj
+++ b/src/Akavache.Mobile/Akavache.Mobile.csproj
@@ -11,9 +11,9 @@
     <Using Remove="Foundation" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="reactiveui" Version="20.2.45" />
-    <PackageReference Include="System.Text.Json" Version="9.0.3" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.3" />
+    <PackageReference Include="reactiveui" Version="20.3.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.6" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Akavache.Sqlite3/Akavache.Sqlite3.csproj
+++ b/src/Akavache.Sqlite3/Akavache.Sqlite3.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.3" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.6" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Akavache.Tests/API/ApiApprovalTests.AkavacheCore.DotNet9_0.verified.txt
+++ b/src/Akavache.Tests/API/ApiApprovalTests.AkavacheCore.DotNet9_0.verified.txt
@@ -6,6 +6,8 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v9.0", FrameworkDisplayName=".NET 9.0")]
 namespace Akavache
 {
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public class AkavacheHttpMixin : Akavache.IAkavacheHttpMixin
     {
         public AkavacheHttpMixin() { }
@@ -18,6 +20,8 @@ namespace Akavache
         public System.IObservable<byte[]> DownloadUrl(Akavache.IBlobCache blobCache, System.Net.Http.HttpMethod method, string key, System.Uri url, System.Collections.Generic.IDictionary<string, string>? headers = null, bool fetchAlways = false, System.DateTimeOffset? absoluteExpiration = default) { }
         public System.IObservable<byte[]> DownloadUrl(Akavache.IBlobCache blobCache, System.Net.Http.HttpMethod method, string key, string url, System.Collections.Generic.IDictionary<string, string>? headers = null, bool fetchAlways = false, System.DateTimeOffset? absoluteExpiration = default) { }
     }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public static class BlobCache
     {
         public static string ApplicationName { get; set; }
@@ -57,6 +61,8 @@ namespace Akavache
         public DefaultAkavacheHttpClientFactory() { }
         public System.Net.Http.HttpClient CreateClient(string name) { }
     }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public static class DependencyResolverMixin
     {
         public static void InitializeAkavache(this Splat.IMutableDependencyResolver resolver, Splat.IReadonlyDependencyResolver readonlyDependencyResolver) { }
@@ -122,6 +128,8 @@ namespace Akavache
     public interface IFilesystemProvider
     {
         System.IObservable<System.Reactive.Unit> CreateRecursive(string path);
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
         System.IObservable<System.Reactive.Unit> Delete(string path);
         string? GetDefaultLocalMachineCacheDirectory();
         string? GetDefaultRoamingCacheDirectory();
@@ -152,6 +160,8 @@ namespace Akavache
         System.IObservable<System.Reactive.Unit> InvalidateObjects<T>(System.Collections.Generic.IEnumerable<string> keys);
     }
     public interface ISecureBlobCache : Akavache.IBlobCache, System.IDisposable { }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public class InMemoryBlobCache : Akavache.IBlobCache, Akavache.IObjectBlobCache, Akavache.ISecureBlobCache, Splat.IEnableLogger, System.IDisposable
     {
         public InMemoryBlobCache() { }
@@ -196,6 +206,8 @@ namespace Akavache
         public static System.IObservable<System.Reactive.Unit> InvalidateAllObjects<T>(this Akavache.IBlobCache blobCache) { }
         public static System.IObservable<System.Reactive.Unit> InvalidateObject<T>(this Akavache.IBlobCache blobCache, string key) { }
     }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public class KeyedOperationQueue : Akavache.IKeyedOperationQueue, Splat.IEnableLogger, System.IDisposable
     {
         public KeyedOperationQueue(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
@@ -231,6 +243,8 @@ namespace Akavache
         public static System.IObservable<System.Reactive.Unit> InsertObject<T>(this Akavache.IBlobCache blobCache, string key, T value, System.TimeSpan expiration) { }
         public static System.IObservable<System.Reactive.Unit> SaveLogin(this Akavache.ISecureBlobCache blobCache, string user, string password, string host, System.TimeSpan expiration) { }
     }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public class SimpleFilesystemProvider : Akavache.IFilesystemProvider
     {
         public SimpleFilesystemProvider() { }
@@ -246,6 +260,8 @@ namespace Akavache
 }
 namespace Akavache.Core
 {
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Core")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Core")]
     public class Registrations
     {
         public Registrations() { }

--- a/src/Akavache.Tests/API/ApiApprovalTests.AkavacheDrawing.DotNet9_0.verified.txt
+++ b/src/Akavache.Tests/API/ApiApprovalTests.AkavacheDrawing.DotNet9_0.verified.txt
@@ -13,6 +13,8 @@ namespace Akavache
 }
 namespace Akavache.Drawing
 {
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache.Drawing")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache.Drawing")]
     public class Registrations
     {
         public Registrations() { }

--- a/src/Akavache.Tests/API/ApiApprovalTests.AkavacheProject.DotNet9_0.verified.txt
+++ b/src/Akavache.Tests/API/ApiApprovalTests.AkavacheProject.DotNet9_0.verified.txt
@@ -1,6 +1,8 @@
 ﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v9.0", FrameworkDisplayName=".NET 9.0")]
 namespace Akavache
 {
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache")]
     public class Registrations
     {
         public Registrations() { }
@@ -11,6 +13,8 @@ namespace Akavache
 namespace Akavache.Sqlite3
 {
     public static class LinkerPreserve { }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registrations for Akavache")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registrations for Akavache")]
     public class SQLitePersistentBlobCache : Akavache.Sqlite3.SqlRawPersistentBlobCache
     {
         public SQLitePersistentBlobCache(string databaseFile, System.Reactive.Concurrency.IScheduler? scheduler = null) { }

--- a/src/Akavache.Tests/Akavache.Tests.csproj
+++ b/src/Akavache.Tests/Akavache.Tests.csproj
@@ -12,21 +12,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="9.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.console" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
     <PackageReference Include="Xunit.StaFact" Version="1.2.69" />
-    <PackageReference Include="ReactiveUI.Testing" Version="20.2.45" />
+    <PackageReference Include="ReactiveUI.Testing" Version="20.3.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
-    <PackageReference Include="FluentAssertions" Version="8.2.0" />
-    <PackageReference Include="DiffEngine" Version="15.11.0" />
-    <PackageReference Include="PublicApiGenerator" Version="11.4.5" />
-    <PackageReference Include="Verify.Xunit" Version="28.15.0" />
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+    <PackageReference Include="DiffEngine" Version="16.2.3" />
+    <PackageReference Include="PublicApiGenerator" Version="11.4.6" />
+    <PackageReference Include="Verify.Xunit" Version="30.4.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Akavache/Akavache.csproj
+++ b/src/Akavache/Akavache.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.3" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Akavache.Sqlite3\Akavache.Sqlite3.csproj" />


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Packages failing to update due to breaking change

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request updates package dependencies across multiple project files to newer versions and adds annotations for dynamic and unreferenced code requirements in API approval tests. These changes enhance compatibility, maintainability, and clarity in code analysis.

### Dependency Updates

* Updated `System.Security.Cryptography.ProtectedData` and `Microsoft.NET.ILLink.Tasks` to version `9.0.6` in `Akavache.Core`, `Akavache.Drawing`, `Akavache.Mobile`, `Akavache.Sqlite3`, and `Akavache` projects. [[1]](diffhunk://#diff-c53de64c92ba8a4ac6ef5d091bd87bf495459fd36b57afb2fe170b96fc0bf844L17-R18) [[2]](diffhunk://#diff-897e7b302da9edde8cf17b0e8b099b0715342732eed27883b18e4912cc5362f6L18-R18) [[3]](diffhunk://#diff-58107fc52acadb68db21b2945429e9237a0d229bd3a77f9af1a20007c2ffda2bL14-R16) [[4]](diffhunk://#diff-f68064be5f27705633c9307f7a863fc7fe7cb9f0da36a5cb23708eb8a36e49b2L17-R17) [[5]](diffhunk://#diff-e8e90709b0f2f4761aa75a1506aca1b16226e775d768b27703ddf0192e350ff7L15-R15)
* Updated `reactiveui` to version `20.3.1` and `System.Text.Json` to version `9.0.6` in `Akavache.Mobile`.
* Updated testing dependencies (`System.Text.Json`, `Microsoft.NET.Test.Sdk`, `ReactiveUI.Testing`, `FluentAssertions`, `DiffEngine`, `PublicApiGenerator`, and `Verify.Xunit`) in `Akavache.Tests` to newer versions.

### Code Analysis Enhancements

* Added `[System.Diagnostics.CodeAnalysis.RequiresDynamicCode]` and `[System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode]` annotations to various classes and methods in API approval test files to indicate dynamic and unreferenced code requirements. This includes classes like `AkavacheHttpMixin`, `BlobCache`, `DependencyResolverMixin`, `InMemoryBlobCache`, `KeyedOperationQueue`, `SimpleFilesystemProvider`, and `Registrations`. [[1]](diffhunk://#diff-d2ab25b19e646702a4c54dee0e89971655bc57dd9986f502607340f935643da0R9-R10) [[2]](diffhunk://#diff-d2ab25b19e646702a4c54dee0e89971655bc57dd9986f502607340f935643da0R23-R24) [[3]](diffhunk://#diff-d2ab25b19e646702a4c54dee0e89971655bc57dd9986f502607340f935643da0R64-R65) [[4]](diffhunk://#diff-d2ab25b19e646702a4c54dee0e89971655bc57dd9986f502607340f935643da0R131-R132) [[5]](diffhunk://#diff-d2ab25b19e646702a4c54dee0e89971655bc57dd9986f502607340f935643da0R163-R164) [[6]](diffhunk://#diff-d2ab25b19e646702a4c54dee0e89971655bc57dd9986f502607340f935643da0R209-R210) [[7]](diffhunk://#diff-d2ab25b19e646702a4c54dee0e89971655bc57dd9986f502607340f935643da0R246-R247) [[8]](diffhunk://#diff-d2ab25b19e646702a4c54dee0e89971655bc57dd9986f502607340f935643da0R263-R264) [[9]](diffhunk://#diff-b109850c3832d3e1f63a4bdcb0dc3a4acb1eede2873be8e114e62d79638ab36aR16-R17) [[10]](diffhunk://#diff-af7564eb45d002987edeca0c1b5a8cd81398e61856408035f293881a7dd3166aR4-R5) [[11]](diffhunk://#diff-af7564eb45d002987edeca0c1b5a8cd81398e61856408035f293881a7dd3166aR16-R17)

**What might this PR break?**

None expected

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

