### PR TITLE
Introduce builder pattern for BlobCache configuration

### DIFF
--- a/src/Akavache.Core/BlobCache.cs
+++ b/src/Akavache.Core/BlobCache.cs
@@ -1,0 +1,163 @@
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+
+namespace Akavache.Core;
+
+/// <summary>
+/// BlobCache is the main entry point for interacting with Akavache. It provides
+/// convenient static properties for accessing common cache locations.
+/// This V11 implementation uses a builder pattern for configuration.
+/// </summary>
+public static class BlobCache
+{
+    private static IBlobCacheBuilder? _builder;
+    private static bool _isInitialized;
+
+    /// <summary>
+    /// Gets or sets the application name used for cache file paths.
+    /// </summary>
+    public static string ApplicationName { get; set; } = "Akavache";
+
+    /// <summary>
+    /// Gets or sets the forced DateTime kind for DateTime serialization.
+    /// When set, all DateTime values will be converted to this kind during cache operations.
+    /// </summary>
+    public static DateTimeKind? ForcedDateTimeKind { get; set; }
+
+    /// <summary>
+    /// Gets the InMemory cache instance. This cache stores data only in memory
+    /// and is lost when the application shuts down. Useful for temporary data
+    /// and session state.
+    /// </summary>
+    public static IBlobCache InMemory => GetOrThrowIfNotInitialized()?.InMemory ??
+        throw new InvalidOperationException("BlobCache has not been initialized. Call BlobCache.Initialize() first.");
+
+    /// <summary>
+    /// Gets a value indicating whether BlobCache has been initialized.
+    /// </summary>
+    public static bool IsInitialized => _isInitialized;
+    /// <summary>
+    /// Gets the LocalMachine cache instance. This cache persists data but is suitable
+    /// for temporary/cached data that can be safely deleted. On mobile platforms,
+    /// the system may delete this data to free up disk space.
+    /// </summary>
+    public static IBlobCache LocalMachine => GetOrThrowIfNotInitialized()?.LocalMachine ??
+        throw new InvalidOperationException("BlobCache has not been initialized. Call BlobCache.Initialize() first.");
+
+    /// <summary>
+    /// Gets the Secure cache instance. This cache provides encrypted storage
+    /// for sensitive data like credentials and API keys.
+    /// </summary>
+    public static ISecureBlobCache Secure => GetOrThrowIfNotInitialized()?.Secure ??
+        throw new InvalidOperationException("BlobCache has not been initialized. Call BlobCache.Initialize() first.");
+
+    /// <summary>
+    /// Gets the UserAccount cache instance. This cache persists data and is suitable
+    /// for storing user settings and preferences that should survive app restarts.
+    /// On some platforms, this data may be backed up to the cloud.
+    /// </summary>
+    public static IBlobCache UserAccount => GetOrThrowIfNotInitialized()?.UserAccount ??
+        throw new InvalidOperationException("BlobCache has not been initialized. Call BlobCache.Initialize() first.");
+    /// <summary>
+    /// Creates a new BlobCache builder for configuration.
+    /// </summary>
+    /// <returns>A new BlobCache builder instance.</returns>
+    public static IBlobCacheBuilder CreateBuilder() => new BlobCacheBuilder();
+
+    /// <summary>
+    /// Initializes BlobCache with default in-memory caches.
+    /// This is the safest default as it doesn't require any additional packages.
+    /// </summary>
+    /// <param name="applicationName">The application name for cache directories. If null, uses the current ApplicationName.</param>
+    /// <returns>A BlobCache builder for further configuration.</returns>
+    public static IBlobCacheBuilder Initialize(string? applicationName = null)
+    {
+        if (applicationName != null)
+        {
+            ApplicationName = applicationName;
+        }
+
+        var builder = CreateBuilder()
+            .WithApplicationName(ApplicationName)
+            .WithInMemoryDefaults();
+
+        return builder.Build();
+    }
+
+    /// <summary>
+    /// Initializes BlobCache with a custom builder configuration.
+    /// </summary>
+    /// <param name="configure">An action to configure the BlobCache builder.</param>
+    /// <returns>The configured builder.</returns>
+    public static IBlobCacheBuilder Initialize(Action<IBlobCacheBuilder> configure)
+    {
+        if (configure == null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+
+        var builder = CreateBuilder().WithApplicationName(ApplicationName);
+        configure(builder);
+        return builder.Build();
+    }
+
+    /// <summary>
+    /// Shuts down all cache instances and flushes any pending operations.
+    /// This should be called before the application terminates to ensure
+    /// all data is properly saved.
+    /// </summary>
+    /// <returns>An observable that completes when shutdown is finished.</returns>
+    public static IObservable<Unit> Shutdown()
+    {
+        if (!_isInitialized || _builder == null)
+        {
+            return Observable.Return(Unit.Default);
+        }
+
+        var shutdownTasks = new List<IObservable<Unit>>();
+
+        try
+        {
+            shutdownTasks.Add(_builder.UserAccount?.Flush() ?? Observable.Return(Unit.Default));
+            shutdownTasks.Add(_builder.LocalMachine?.Flush() ?? Observable.Return(Unit.Default));
+            shutdownTasks.Add(_builder.Secure?.Flush() ?? Observable.Return(Unit.Default));
+            shutdownTasks.Add(_builder.InMemory?.Flush() ?? Observable.Return(Unit.Default));
+        }
+        catch (Exception ex)
+        {
+            return Observable.Throw<Unit>(ex);
+        }
+
+        return shutdownTasks.Count > 0
+            ? Observable.Merge(shutdownTasks).TakeLast(1).Select(_ => Unit.Default)
+            : Observable.Return(Unit.Default);
+    }
+
+    /// <summary>
+    /// Internal method to set the builder instance. Used by the builder pattern.
+    /// </summary>
+    /// <param name="builder">The configured builder instance.</param>
+    internal static void SetBuilder(IBlobCacheBuilder builder)
+    {
+        _builder = builder;
+        _isInitialized = true;
+    }
+
+    private static IBlobCacheBuilder? GetOrThrowIfNotInitialized()
+    {
+        if (!_isInitialized)
+        {
+            throw new InvalidOperationException(
+                "BlobCache has not been initialized. " +
+                "Call BlobCache.Initialize() or BlobCache.Initialize(builder => { ... }) first. " +
+                "For more advanced scenarios, use BlobCache.CreateBuilder() to configure custom cache implementations.");
+        }
+
+        return _builder;
+    }
+}

--- a/src/Akavache.Core/BlobCacheBuilder.cs
+++ b/src/Akavache.Core/BlobCacheBuilder.cs
@@ -1,0 +1,220 @@
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Akavache.Core;
+
+/// <summary>
+/// Default implementation of IBlobCacheBuilder.
+/// </summary>
+internal class BlobCacheBuilder : IBlobCacheBuilder
+{
+    private string _applicationName = "Akavache";
+
+    /// <inheritdoc />
+    public IBlobCache? InMemory { get; private set; }
+
+    /// <inheritdoc />
+    public IBlobCache? LocalMachine { get; private set; }
+
+    /// <inheritdoc />
+    public ISecureBlobCache? Secure { get; private set; }
+
+    /// <inheritdoc />
+    public IBlobCache? UserAccount { get; private set; }
+    /// <inheritdoc />
+    public IBlobCacheBuilder Build()
+    {
+        BlobCache.SetBuilder(this);
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IBlobCacheBuilder WithApplicationName(string applicationName)
+    {
+        _applicationName = applicationName ?? throw new ArgumentNullException(nameof(applicationName));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IBlobCacheBuilder WithInMemory(IBlobCache cache)
+    {
+        InMemory = cache ?? throw new ArgumentNullException(nameof(cache));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IBlobCacheBuilder WithInMemoryDefaults()
+    {
+        if (CoreRegistrations.Serializer == null)
+        {
+            throw new InvalidOperationException("No serializer has been registered. Call CoreRegistrations.Serializer = new [SerializerType]() before using InMemory defaults.");
+        }
+
+        UserAccount ??= BlobCacheBuilder.CreateInMemoryCache();
+        LocalMachine ??= BlobCacheBuilder.CreateInMemoryCache();
+        Secure ??= new SecureBlobCacheWrapper(BlobCacheBuilder.CreateInMemoryCache());
+        InMemory ??= BlobCacheBuilder.CreateInMemoryCache();
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IBlobCacheBuilder WithLocalMachine(IBlobCache cache)
+    {
+        LocalMachine = cache ?? throw new ArgumentNullException(nameof(cache));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IBlobCacheBuilder WithSecure(ISecureBlobCache cache)
+    {
+        Secure = cache ?? throw new ArgumentNullException(nameof(cache));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IBlobCacheBuilder WithUserAccount(IBlobCache cache)
+    {
+        UserAccount = cache ?? throw new ArgumentNullException(nameof(cache));
+        return this;
+    }
+
+    private static void ApplyForcedDateTimeKind(IBlobCache cache)
+    {
+        if (BlobCache.ForcedDateTimeKind.HasValue)
+        {
+            cache.ForcedDateTimeKind = BlobCache.ForcedDateTimeKind.Value;
+        }
+    }
+
+    private static IBlobCache CreateInMemoryCache()
+    {
+        if (CoreRegistrations.Serializer == null)
+        {
+            throw new InvalidOperationException("No serializer has been registered. Call CoreRegistrations.Serializer = new [SerializerType]() before using BlobCache.");
+        }
+
+        var serializerType = CoreRegistrations.Serializer.GetType();
+
+        // Try to create the appropriate InMemoryBlobCache based on serializer
+        if (serializerType.Namespace?.Contains("SystemTextJson") == true)
+        {
+            var type = Type.GetType("Akavache.SystemTextJson.InMemoryBlobCache, Akavache.SystemTextJson");
+            if (type != null)
+            {
+                var cache = (IBlobCache)Activator.CreateInstance(type)!;
+                ApplyForcedDateTimeKind(cache);
+                return cache;
+            }
+        }
+        else if (serializerType.Namespace?.Contains("NewtonsoftJson") == true)
+        {
+            var type = Type.GetType("Akavache.NewtonsoftJson.InMemoryBlobCache, Akavache.NewtonsoftJson");
+            if (type != null)
+            {
+                var cache = (IBlobCache)Activator.CreateInstance(type)!;
+                ApplyForcedDateTimeKind(cache);
+                return cache;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "No suitable InMemoryBlobCache implementation found. " +
+            "Install one of: Akavache.SystemTextJson or Akavache.NewtonsoftJson packages and ensure a serializer is registered.");
+    }
+
+    /// <summary>
+    /// A wrapper that implements ISecureBlobCache by delegating to an IBlobCache.
+    /// </summary>
+    private class SecureBlobCacheWrapper : ISecureBlobCache
+    {
+        private readonly IBlobCache _inner;
+
+        public SecureBlobCacheWrapper(IBlobCache inner)
+        {
+            _inner = inner;
+        }
+
+        public DateTimeKind? ForcedDateTimeKind
+        {
+            get => _inner.ForcedDateTimeKind;
+            set => _inner.ForcedDateTimeKind = value;
+        }
+
+        public IScheduler Scheduler => _inner.Scheduler;
+
+        public void Dispose()
+        {
+            if (_inner is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_inner is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync();
+            }
+            else if (_inner is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+
+        public IObservable<Unit> Flush() => _inner.Flush();
+
+        public IObservable<Unit> Flush(Type type) => _inner.Flush(type);
+
+        public IObservable<byte[]?> Get(string key) => _inner.Get(key);
+
+        public IObservable<KeyValuePair<string, byte[]>> Get(IEnumerable<string> keys) => _inner.Get(keys);
+
+        public IObservable<byte[]?> Get(string key, Type type) => _inner.Get(key, type);
+
+        public IObservable<KeyValuePair<string, byte[]>> Get(IEnumerable<string> keys, Type type) => _inner.Get(keys, type);
+
+        public IObservable<KeyValuePair<string, byte[]>> GetAll(Type type) => _inner.GetAll(type);
+
+        public IObservable<string> GetAllKeys() => _inner.GetAllKeys();
+
+        public IObservable<string> GetAllKeys(Type type) => _inner.GetAllKeys(type);
+
+        public IObservable<(string Key, DateTimeOffset? Time)> GetCreatedAt(IEnumerable<string> keys) => _inner.GetCreatedAt(keys);
+
+        public IObservable<DateTimeOffset?> GetCreatedAt(string key) => _inner.GetCreatedAt(key);
+
+        public IObservable<(string Key, DateTimeOffset? Time)> GetCreatedAt(IEnumerable<string> keys, Type type) => _inner.GetCreatedAt(keys, type);
+
+        public IObservable<DateTimeOffset?> GetCreatedAt(string key, Type type) => _inner.GetCreatedAt(key, type);
+
+        public IObservable<Unit> Insert(IEnumerable<KeyValuePair<string, byte[]>> keyValuePairs, DateTimeOffset? absoluteExpiration = null) =>
+                                                                                                                                    _inner.Insert(keyValuePairs, absoluteExpiration);
+
+        public IObservable<Unit> Insert(string key, byte[] data, DateTimeOffset? absoluteExpiration = null) =>
+            _inner.Insert(key, data, absoluteExpiration);
+
+        public IObservable<Unit> Insert(IEnumerable<KeyValuePair<string, byte[]>> keyValuePairs, Type type, DateTimeOffset? absoluteExpiration = null) =>
+            _inner.Insert(keyValuePairs, type, absoluteExpiration);
+
+        public IObservable<Unit> Insert(string key, byte[] data, Type type, DateTimeOffset? absoluteExpiration = null) =>
+            _inner.Insert(key, data, type, absoluteExpiration);
+
+        public IObservable<Unit> Invalidate(string key) => _inner.Invalidate(key);
+
+        public IObservable<Unit> Invalidate(string key, Type type) => _inner.Invalidate(key, type);
+
+        public IObservable<Unit> Invalidate(IEnumerable<string> keys) => _inner.Invalidate(keys);
+
+        public IObservable<Unit> Invalidate(IEnumerable<string> keys, Type type) => _inner.Invalidate(keys, type);
+
+        public IObservable<Unit> InvalidateAll(Type type) => _inner.InvalidateAll(type);
+
+        public IObservable<Unit> InvalidateAll() => _inner.InvalidateAll();
+
+        public IObservable<Unit> Vacuum() => _inner.Vacuum();
+    }
+}

--- a/src/Akavache.Core/IBlobCacheBuilder.cs
+++ b/src/Akavache.Core/IBlobCacheBuilder.cs
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Akavache.Core;
+
+/// <summary>
+/// Interface for building and configuring BlobCache instances.
+/// </summary>
+public interface IBlobCacheBuilder
+{
+    /// <summary>
+    /// Gets the UserAccount cache instance.
+    /// </summary>
+    IBlobCache? UserAccount { get; }
+
+    /// <summary>
+    /// Gets the LocalMachine cache instance.
+    /// </summary>
+    IBlobCache? LocalMachine { get; }
+
+    /// <summary>
+    /// Gets the Secure cache instance.
+    /// </summary>
+    ISecureBlobCache? Secure { get; }
+
+    /// <summary>
+    /// Gets the InMemory cache instance.
+    /// </summary>
+    IBlobCache? InMemory { get; }
+
+    /// <summary>
+    /// Sets the application name for cache directory paths.
+    /// </summary>
+    /// <param name="applicationName">The application name.</param>
+    /// <returns>The builder instance for fluent configuration.</returns>
+    IBlobCacheBuilder WithApplicationName(string applicationName);
+
+    /// <summary>
+    /// Sets the UserAccount cache instance.
+    /// </summary>
+    /// <param name="cache">The cache instance to use for UserAccount operations.</param>
+    /// <returns>The builder instance for fluent configuration.</returns>
+    IBlobCacheBuilder WithUserAccount(IBlobCache cache);
+
+    /// <summary>
+    /// Sets the LocalMachine cache instance.
+    /// </summary>
+    /// <param name="cache">The cache instance to use for LocalMachine operations.</param>
+    /// <returns>The builder instance for fluent configuration.</returns>
+    IBlobCacheBuilder WithLocalMachine(IBlobCache cache);
+
+    /// <summary>
+    /// Sets the Secure cache instance.
+    /// </summary>
+    /// <param name="cache">The secure cache instance to use for Secure operations.</param>
+    /// <returns>The builder instance for fluent configuration.</returns>
+    IBlobCacheBuilder WithSecure(ISecureBlobCache cache);
+
+    /// <summary>
+    /// Sets the InMemory cache instance.
+    /// </summary>
+    /// <param name="cache">The cache instance to use for InMemory operations.</param>
+    /// <returns>The builder instance for fluent configuration.</returns>
+    IBlobCacheBuilder WithInMemory(IBlobCache cache);
+
+    /// <summary>
+    /// Configures default in-memory caches for all cache types.
+    /// Uses the appropriate InMemoryBlobCache based on the configured serializer.
+    /// </summary>
+    /// <returns>The builder instance for fluent configuration.</returns>
+    IBlobCacheBuilder WithInMemoryDefaults();
+
+    /// <summary>
+    /// Builds and applies the configuration to BlobCache.
+    /// </summary>
+    /// <returns>The builder instance.</returns>
+    IBlobCacheBuilder Build();
+}

--- a/src/Akavache.Drawing/Size.cs
+++ b/src/Akavache.Drawing/Size.cs
@@ -72,7 +72,7 @@ public readonly struct Size(float width, float height) : IEquatable<Size>
             return hash;
         }
 #else
-            return HashCode.Combine(Width, Height);
+        return HashCode.Combine(Width, Height);
 #endif
     }
 }

--- a/src/Akavache.EncryptedSqlite3/Akavache.EncryptedSqlite3.csproj
+++ b/src/Akavache.EncryptedSqlite3/Akavache.EncryptedSqlite3.csproj
@@ -15,6 +15,8 @@
   <ItemGroup>
     <Compile Include="../Akavache.Sqlite3/CacheEntry.cs" />
     <Compile Include="../Akavache.Sqlite3/SqliteBlobCache.cs" />
+    <Compile Include="../Akavache.Sqlite3/Registrations.cs" />
+    <Compile Include="../Akavache.Sqlite3/BlobCacheBuilderExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Akavache.Sqlite3/BlobCacheBuilderExtensions.cs
+++ b/src/Akavache.Sqlite3/BlobCacheBuilderExtensions.cs
@@ -1,0 +1,300 @@
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+using Akavache.Core;
+
+#if ENCRYPTED
+namespace Akavache.EncryptedSqlite3;
+#else
+namespace Akavache.Sqlite3;
+#endif
+
+/// <summary>
+/// Extension methods for IBlobCacheBuilder to add SQLite support.
+/// </summary>
+public static class BlobCacheBuilderExtensions
+{
+#if ENCRYPTED
+    /// <summary>
+    /// Configures default SQLite-based caches for all cache types.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="password">The password.</param>
+    /// <returns>
+    /// The builder instance for fluent configuration.
+    /// </returns>
+    /// <exception cref="System.ArgumentNullException">builder.</exception>
+    /// <exception cref="System.InvalidOperationException">
+    /// No serializer has been registered. Call CoreRegistrations.Serializer = new [SerializerType]() before using SQLite defaults.
+    /// or
+    /// Application name must be set before configuring SQLite defaults. Call WithApplicationName() first.
+    /// </exception>
+    public static IBlobCacheBuilder WithSqliteDefaults(this IBlobCacheBuilder builder, string password)
+#else
+    /// <summary>
+    /// Configures default SQLite-based caches for all cache types.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <returns>The builder instance for fluent configuration.</returns>
+    public static IBlobCacheBuilder WithSqliteDefaults(this IBlobCacheBuilder builder)
+#endif
+    {
+        if (builder == null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        if (CoreRegistrations.Serializer == null)
+        {
+            throw new InvalidOperationException("No serializer has been registered. Call CoreRegistrations.Serializer = new [SerializerType]() before using SQLite defaults.");
+        }
+
+        var applicationName = BlobCache.ApplicationName;
+        if (string.IsNullOrWhiteSpace(applicationName))
+        {
+            throw new InvalidOperationException("Application name must be set before configuring SQLite defaults. Call WithApplicationName() first.");
+        }
+
+#if ENCRYPTED
+        // Create SQLite caches for persistent storage
+        builder.WithUserAccount(CreateEncryptedSqliteCache("UserAccount", applicationName, password))
+               .WithLocalMachine(CreateEncryptedSqliteCache("LocalMachine", applicationName, password))
+               .WithInMemory(CreateEncryptedSqliteCache(":memory:", applicationName, password))
+               .WithSecure(CreateEncryptedSqliteCache("Secure", applicationName, password));
+#else
+        // Create SQLite caches for persistent storage
+        builder.WithUserAccount(CreateSqliteCache("UserAccount", applicationName))
+               .WithLocalMachine(CreateSqliteCache("LocalMachine", applicationName))
+               .WithInMemory(CreateSqliteCache(":memory:", applicationName))
+               .WithSecure(new SecureBlobCacheWrapper(CreateSqliteCache("Secure", applicationName)));
+#endif
+
+        return builder;
+    }
+
+#if ENCRYPTED
+    private static EncryptedSqliteBlobCache CreateEncryptedSqliteCache(string name, string applicationName, string password)
+#else
+    private static SqliteBlobCache CreateSqliteCache(string name, string applicationName)
+#endif
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Cache name cannot be null or empty.", nameof(name));
+        }
+
+        if (string.IsNullOrWhiteSpace(applicationName))
+        {
+            throw new ArgumentException("Application name cannot be null or empty.", nameof(applicationName));
+        }
+
+        string filePath;
+        if (name == ":memory:")
+        {
+            filePath = ":memory:";
+        }
+        else
+        {
+            var directory = GetCacheDirectory(name, applicationName);
+            try
+            {
+                Directory.CreateDirectory(directory);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to create cache directory '{directory}': {ex.Message}", ex);
+            }
+
+            filePath = Path.Combine(directory, $"{name}.db");
+        }
+
+#if ENCRYPTED
+        var cache = new EncryptedSqliteBlobCache(filePath, password);
+#else
+        var cache = new SqliteBlobCache(filePath);
+#endif
+        if (BlobCache.ForcedDateTimeKind.HasValue)
+        {
+            cache.ForcedDateTimeKind = BlobCache.ForcedDateTimeKind.Value;
+        }
+
+        return cache;
+    }
+
+    ////private static ISecureBlobCache CreateEncryptedSqliteCache(string name, string applicationName)
+    ////{
+    ////    if (string.IsNullOrWhiteSpace(name))
+    ////    {
+    ////        throw new ArgumentException("Cache name cannot be null or empty.", nameof(name));
+    ////    }
+
+    ////    if (string.IsNullOrWhiteSpace(applicationName))
+    ////    {
+    ////        throw new ArgumentException("Application name cannot be null or empty.", nameof(applicationName));
+    ////    }
+
+    ////    var directory = GetCacheDirectory(name, applicationName);
+    ////    try
+    ////    {
+    ////        Directory.CreateDirectory(directory);
+    ////    }
+    ////    catch (Exception ex)
+    ////    {
+    ////        throw new InvalidOperationException($"Failed to create cache directory '{directory}': {ex.Message}", ex);
+    ////    }
+
+    ////    var filePath = Path.Combine(directory, $"{name}.db");
+
+    ////    // For encrypted cache, we need a password. Use a default that can be overridden.
+    ////    var password = Environment.GetEnvironmentVariable("AKAVACHE_SECURE_PASSWORD") ?? "DefaultSecurePassword";
+
+    ////    var encryptedType = Type.GetType("Akavache.EncryptedSqlite3.EncryptedSqliteBlobCache, Akavache.EncryptedSqlite3");
+    ////    if (encryptedType == null)
+    ////    {
+    ////        throw new InvalidOperationException("Akavache.EncryptedSqlite3.EncryptedSqliteBlobCache type not found. Ensure Akavache.EncryptedSqlite3 is properly referenced.");
+    ////    }
+
+    ////    var cache = (ISecureBlobCache)Activator.CreateInstance(encryptedType, filePath, password)!;
+
+    ////    if (BlobCache.ForcedDateTimeKind.HasValue)
+    ////    {
+    ////        cache.ForcedDateTimeKind = BlobCache.ForcedDateTimeKind.Value;
+    ////    }
+
+    ////    return cache;
+    ////}
+
+    private static string GetCacheDirectory(string cacheName, string applicationName)
+    {
+        if (string.IsNullOrWhiteSpace(cacheName))
+        {
+            throw new ArgumentException("Cache name cannot be null or empty.", nameof(cacheName));
+        }
+
+        if (string.IsNullOrWhiteSpace(applicationName))
+        {
+            throw new ArgumentException("Application name cannot be null or empty.", nameof(applicationName));
+        }
+
+        var baseDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(baseDirectory))
+        {
+            throw new InvalidOperationException("Unable to determine local application data directory.");
+        }
+
+        return Path.Combine(baseDirectory, applicationName, cacheName);
+    }
+
+#if !ENCRYPTED
+    /// <summary>
+    /// A wrapper that implements ISecureBlobCache by delegating to an IBlobCache.
+    /// </summary>
+    private class SecureBlobCacheWrapper(IBlobCache inner) : ISecureBlobCache
+    {
+        private readonly IBlobCache _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        private bool _disposed;
+
+        public DateTimeKind? ForcedDateTimeKind
+        {
+            get => _inner.ForcedDateTimeKind;
+            set => _inner.ForcedDateTimeKind = value;
+        }
+
+        public IScheduler Scheduler => _inner.Scheduler;
+
+        public IObservable<Unit> Insert(IEnumerable<KeyValuePair<string, byte[]>> keyValuePairs, DateTimeOffset? absoluteExpiration = null) =>
+            _inner.Insert(keyValuePairs, absoluteExpiration);
+
+        public IObservable<Unit> Insert(string key, byte[] data, DateTimeOffset? absoluteExpiration = null) =>
+            _inner.Insert(key, data, absoluteExpiration);
+
+        public IObservable<Unit> Insert(IEnumerable<KeyValuePair<string, byte[]>> keyValuePairs, Type type, DateTimeOffset? absoluteExpiration = null) =>
+            _inner.Insert(keyValuePairs, type, absoluteExpiration);
+
+        public IObservable<Unit> Insert(string key, byte[] data, Type type, DateTimeOffset? absoluteExpiration = null) =>
+            _inner.Insert(key, data, type, absoluteExpiration);
+
+        public IObservable<byte[]?> Get(string key) => _inner.Get(key);
+
+        public IObservable<KeyValuePair<string, byte[]>> Get(IEnumerable<string> keys) => _inner.Get(keys);
+
+        public IObservable<byte[]?> Get(string key, Type type) => _inner.Get(key, type);
+
+        public IObservable<KeyValuePair<string, byte[]>> Get(IEnumerable<string> keys, Type type) => _inner.Get(keys, type);
+
+        public IObservable<KeyValuePair<string, byte[]>> GetAll(Type type) => _inner.GetAll(type);
+
+        public IObservable<string> GetAllKeys() => _inner.GetAllKeys();
+
+        public IObservable<string> GetAllKeys(Type type) => _inner.GetAllKeys(type);
+
+        public IObservable<(string Key, DateTimeOffset? Time)> GetCreatedAt(IEnumerable<string> keys) => _inner.GetCreatedAt(keys);
+
+        public IObservable<DateTimeOffset?> GetCreatedAt(string key) => _inner.GetCreatedAt(key);
+
+        public IObservable<(string Key, DateTimeOffset? Time)> GetCreatedAt(IEnumerable<string> keys, Type type) => _inner.GetCreatedAt(keys, type);
+
+        public IObservable<DateTimeOffset?> GetCreatedAt(string key, Type type) => _inner.GetCreatedAt(key, type);
+
+        public IObservable<Unit> Flush() => _inner.Flush();
+
+        public IObservable<Unit> Flush(Type type) => _inner.Flush(type);
+
+        public IObservable<Unit> Invalidate(string key) => _inner.Invalidate(key);
+
+        public IObservable<Unit> Invalidate(string key, Type type) => _inner.Invalidate(key, type);
+
+        public IObservable<Unit> Invalidate(IEnumerable<string> keys) => _inner.Invalidate(keys);
+
+        public IObservable<Unit> InvalidateAll(Type type) => _inner.InvalidateAll(type);
+
+        public IObservable<Unit> Invalidate(IEnumerable<string> keys, Type type) => _inner.Invalidate(keys, type);
+
+        public IObservable<Unit> InvalidateAll() => _inner.InvalidateAll();
+
+        public IObservable<Unit> Vacuum() => _inner.Vacuum();
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore().ConfigureAwait(false);
+            Dispose(false);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed && disposing)
+            {
+                if (_inner is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            if (_inner is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+            }
+            else if (_inner is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+#endif
+}

--- a/src/Akavache.Sqlite3/Registrations.cs
+++ b/src/Akavache.Sqlite3/Registrations.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Akavache.Core;
+
+#if ENCRYPTED
+namespace Akavache.EncryptedSqlite3;
+#else
+namespace Akavache.Sqlite3;
+#endif
+
+/// <summary>
+/// Registration helpers for SQLite-based Akavache initialization.
+/// </summary>
+public static class Registrations
+{
+#if ENCRYPTED
+    /// <summary>
+    /// Initializes Akavache with SQLite defaults and configures the serializer.
+    /// </summary>
+    /// <param name="applicationName">The application name for cache directories.</param>
+    /// <param name="password">The password.</param>
+    /// <param name="initializeSqlite">Optional SQLite initialization action.</param>
+    /// <exception cref="System.ArgumentException">Application name cannot be null or empty. - applicationName.</exception>
+    public static void Start(string applicationName, string password, Action? initializeSqlite = null)
+#else
+    /// <summary>
+    /// Initializes Akavache with SQLite defaults and configures the serializer.
+    /// </summary>
+    /// <param name="applicationName">The application name for cache directories.</param>
+    /// <param name="initializeSqlite">Optional SQLite initialization action.</param>
+    public static void Start(string applicationName, Action? initializeSqlite = null)
+#endif
+    {
+        if (string.IsNullOrWhiteSpace(applicationName))
+        {
+            throw new ArgumentException("Application name cannot be null or empty.", nameof(applicationName));
+        }
+
+        // Initialize SQLite if provided
+        initializeSqlite?.Invoke();
+
+        // Initialize BlobCache with SQLite defaults
+        BlobCache.Initialize(builder =>
+        {
+            builder.WithApplicationName(applicationName);
+#if ENCRYPTED
+            builder.WithSqliteDefaults(password);
+#else
+            builder.WithSqliteDefaults();
+#endif
+        });
+    }
+}


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

feature

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

With Akavache versions <= 10 a Splat magic registration approach is taken

**What is the new behavior?**
<!-- If this is a feature change -->

Version 11 will introduce the option to use a Builder approach due to the number of options that can exist.

This pull request introduces significant updates to the Akavache library, focusing on a new builder-based configuration system for `BlobCache`, improvements to code maintainability, and minor refactoring in benchmark files. Below are the most important changes grouped by theme:

### Major Features: Builder Pattern for `BlobCache`

* Introduced a new `BlobCache` class with a builder-based configuration system, allowing flexible initialization and management of cache instances (`InMemory`, `LocalMachine`, `Secure`, `UserAccount`). This includes methods like `Initialize()`, `CreateBuilder()`, and `Shutdown()` for streamlined cache setup and teardown. (`src/Akavache.Core/BlobCache.cs`, [src/Akavache.Core/BlobCache.csR1-R163](diffhunk://#diff-ff4353532e300af49040dafe45b10acbe189a9bc4d48cb034f9d52ddd311c410R1-R163))
* Added a `BlobCacheBuilder` class implementing the `IBlobCacheBuilder` interface. This class provides fluent configuration methods (`WithApplicationName`, `WithInMemoryDefaults`, etc.) and ensures proper initialization of cache instances. (`src/Akavache.Core/BlobCacheBuilder.cs`, [src/Akavache.Core/BlobCacheBuilder.csR1-R220](diffhunk://#diff-3006d92c8a2b8099edc98806113b1541720314eb1f2c7fcf904c92579c2be01cR1-R220))
* Defined the `IBlobCacheBuilder` interface to standardize the configuration of `BlobCache` instances, supporting custom cache implementations and in-memory defaults. (`src/Akavache.Core/IBlobCacheBuilder.cs`, [src/Akavache.Core/IBlobCacheBuilder.csR1-R80](diffhunk://#diff-9011effcf6b843fbf3912efd4044e622a7537979d6b0c2d1d910c6bf7fdf0c3dR1-R80))

### Refactoring and Code Improvements

* Updated the `CacheDatabaseReadBenchmarks` class to use modern C# syntax (e.g., target-typed `new` for object instantiation) and replaced the method return type `IBlobCache` with the more specific `Sqlite3.SqliteBlobCache`. (`src/Akavache.Benchmarks/CacheDatabaseReadBenchmarks.cs`, [[1]](diffhunk://#diff-e0207cc446b095d876a455fcf19533f0a489e47784909092785e23e863abdd65L7) [[2]](diffhunk://#diff-e0207cc446b095d876a455fcf19533f0a489e47784909092785e23e863abdd65L26-R25) [[3]](diffhunk://#diff-e0207cc446b095d876a455fcf19533f0a489e47784909092785e23e863abdd65L106-R105)

### Project Configuration

* Added shared files (`Registrations.cs` and `BlobCacheBuilderExtensions.cs`) to the `Akavache.EncryptedSqlite3` project for compatibility with the new builder pattern. (`src/Akavache.EncryptedSqlite3/Akavache.EncryptedSqlite3.csproj`, [src/Akavache.EncryptedSqlite3/Akavache.EncryptedSqlite3.csprojR18-R19](diffhunk://#diff-d56f4d6bd9072f22f9830c44de4ae92b2e8df800303b4afffecb1eb56e5152d1R18-R19))

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

