### PR TITLE
Add Legacy FileLocationOption for cache directory selection

### DIFF
--- a/src/Akavache.Core/CacheDatabase.cs
+++ b/src/Akavache.Core/CacheDatabase.cs
@@ -142,15 +142,14 @@ public static class CacheDatabase
     /// </summary>
     /// <typeparam name="T">The serializer.</typeparam>
     /// <param name="applicationName">The application name for cache directories. If null, uses the current ApplicationName.</param>
+    /// <param name="fileLocationOption">The file location option.</param>
     /// <exception cref="InvalidOperationException">Failed to create AkavacheBuilder instance.</exception>
 #if NET6_0_OR_GREATER
-
     [RequiresUnreferencedCode("Serializers require types to be preserved for serialization.")]
-    public static void Initialize<T>(string? applicationName = null)
-#else
-    public static void Initialize<T>(string? applicationName = null)
 #endif
-       where T : ISerializer, new() => SetBuilder(CreateBuilder()
+    public static void Initialize<T>(string? applicationName = null, FileLocationOption fileLocationOption = FileLocationOption.Default)
+
+       where T : ISerializer, new() => SetBuilder(CreateBuilder(fileLocationOption)
             .WithApplicationName(applicationName)
             .WithSerializer<T>()
             .WithInMemoryDefaults()
@@ -163,15 +162,12 @@ public static class CacheDatabase
     /// <typeparam name="T">The serializer.</typeparam>
     /// <param name="configureSerializer">The Serializer configuration.</param>
     /// <param name="applicationName">The application name for cache directories. If null, uses the current ApplicationName.</param>
-    /// <exception cref="InvalidOperationException">Failed to create AkavacheBuilder instance.</exception>
+    /// <param name="fileLocationOption">The file location option.</param>
 #if NET6_0_OR_GREATER
-
     [RequiresUnreferencedCode("Serializers require types to be preserved for serialization.")]
-    public static void Initialize<T>(Func<T> configureSerializer, string? applicationName = null)
-#else
-    public static void Initialize<T>(Func<T> configureSerializer, string? applicationName = null)
 #endif
-       where T : ISerializer, new() => SetBuilder(CreateBuilder()
+    public static void Initialize<T>(Func<T> configureSerializer, string? applicationName = null, FileLocationOption fileLocationOption = FileLocationOption.Default)
+       where T : ISerializer, new() => SetBuilder(CreateBuilder(fileLocationOption)
             .WithApplicationName(applicationName)
             .WithSerializer(configureSerializer)
             .WithInMemoryDefaults()
@@ -183,14 +179,11 @@ public static class CacheDatabase
     /// <typeparam name="T">The serializer.</typeparam>
     /// <param name="configure">An action to configure the Akavache builder.</param>
     /// <param name="applicationName">Name of the application.</param>
-    /// <exception cref="ArgumentNullException">configure.</exception>
+    /// <param name="fileLocationOption">The file location option.</param>
 #if NET6_0_OR_GREATER
-
     [RequiresUnreferencedCode("Serializers require types to be preserved for serialization.")]
-    public static void Initialize<T>(Action<IAkavacheBuilder> configure, string? applicationName = null)
-#else
-    public static void Initialize<T>(Action<IAkavacheBuilder> configure, string? applicationName = null)
 #endif
+    public static void Initialize<T>(Action<IAkavacheBuilder> configure, string? applicationName = null, FileLocationOption fileLocationOption = FileLocationOption.Default)
         where T : ISerializer, new()
     {
         if (configure == null)
@@ -198,7 +191,7 @@ public static class CacheDatabase
             throw new ArgumentNullException(nameof(configure));
         }
 
-        var builder = CreateBuilder()
+        var builder = CreateBuilder(fileLocationOption)
             .WithApplicationName(applicationName)
             .WithSerializer<T>();
 
@@ -214,14 +207,11 @@ public static class CacheDatabase
     /// <param name="configureSerializer">The Serializer configuration.</param>
     /// <param name="configure">An action to configure the Akavache builder.</param>
     /// <param name="applicationName">Name of the application.</param>
-    /// <exception cref="ArgumentNullException">configure.</exception>
+    /// <param name="fileLocationOption">The file location option.</param>
 #if NET6_0_OR_GREATER
-
     [RequiresUnreferencedCode("Serializers require types to be preserved for serialization.")]
-    public static void Initialize<T>(Func<T> configureSerializer, Action<IAkavacheBuilder> configure, string? applicationName = null)
-#else
-    public static void Initialize<T>(Func<T> configureSerializer, Action<IAkavacheBuilder> configure, string? applicationName = null)
 #endif
+    public static void Initialize<T>(Func<T> configureSerializer, Action<IAkavacheBuilder> configure, string? applicationName = null, FileLocationOption fileLocationOption = FileLocationOption.Default)
         where T : ISerializer, new()
     {
         if (configure == null)
@@ -229,7 +219,7 @@ public static class CacheDatabase
             throw new ArgumentNullException(nameof(configure));
         }
 
-        var builder = CreateBuilder()
+        var builder = CreateBuilder(fileLocationOption)
             .WithApplicationName(applicationName)
             .WithSerializer(configureSerializer);
 
@@ -241,8 +231,11 @@ public static class CacheDatabase
     /// <summary>
     /// Creates a new Akavache builder for configuration.
     /// </summary>
-    /// <returns>A new Akavache builder instance.</returns>
-    public static IAkavacheBuilder CreateBuilder() => new AkavacheBuilder();
+    /// <param name="fileLocationOption">The file location option.</param>
+    /// <returns>
+    /// A new Akavache builder instance.
+    /// </returns>
+    public static IAkavacheBuilder CreateBuilder(FileLocationOption fileLocationOption = FileLocationOption.Default) => new AkavacheBuilder(fileLocationOption);
 
     /// <summary>
     /// Internal method to set the builder instance. Used by the builder pattern.

--- a/src/Akavache.Core/Core/AkavacheBuilder.cs
+++ b/src/Akavache.Core/Core/AkavacheBuilder.cs
@@ -18,10 +18,12 @@ internal class AkavacheBuilder : IAkavacheBuilder
 {
     private static readonly object _lock = new();
     private string? _settingsCachePath;
+    private FileLocationOption _fileLocationOption;
 
     [SuppressMessage("ExecutingAssembly.Location", "IL3000:String may be null", Justification = "Handled.")]
-    public AkavacheBuilder()
+    public AkavacheBuilder(FileLocationOption fileLocationOption = FileLocationOption.Default)
     {
+        _fileLocationOption = fileLocationOption;
         try
         {
             ExecutingAssemblyName = ExecutingAssembly.FullName!.Split(',')[0];
@@ -73,7 +75,11 @@ internal class AkavacheBuilder : IAkavacheBuilder
             // Lazy computation to ensure ApplicationName is properly set via WithApplicationName()
             if (_settingsCachePath == null)
             {
-                _settingsCachePath = this.GetIsolatedCacheDirectory("SettingsCache");
+                _settingsCachePath = _fileLocationOption switch
+                {
+                    FileLocationOption.Legacy => this.GetLegacyCacheDirectory("SettingsCache"),
+                    _ => this.GetIsolatedCacheDirectory("SettingsCache"),
+                };
             }
 
             return _settingsCachePath;
@@ -118,6 +124,14 @@ internal class AkavacheBuilder : IAkavacheBuilder
     /// The name of the serializer type.
     /// </value>
     public string? SerializerTypeName { get; internal set; }
+
+    /// <summary>
+    /// Gets the file location option.
+    /// </summary>
+    /// <value>
+    /// The file location option.
+    /// </value>
+    public FileLocationOption FileLocationOption => _fileLocationOption;
 
     internal static Dictionary<string, IBlobCache?>? BlobCaches { get; set; } = [];
 

--- a/src/Akavache.Core/Core/FileLocationOption.cs
+++ b/src/Akavache.Core/Core/FileLocationOption.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Akavache.Core
+{
+    /// <summary>
+    /// File Location Option.
+    /// </summary>
+    public enum FileLocationOption
+    {
+        /// <summary>
+        /// Use the default location for the platform.
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Use the legacy location, if available on the platform.
+        /// </summary>
+        Legacy,
+    }
+}

--- a/src/Akavache.Core/IAkavacheBuilder.cs
+++ b/src/Akavache.Core/IAkavacheBuilder.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Akavache.Core;
 #if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
@@ -14,6 +15,14 @@ namespace Akavache;
 /// </summary>
 public interface IAkavacheBuilder : IAkavacheInstance
 {
+    /// <summary>
+    /// Gets the file location option.
+    /// </summary>
+    /// <value>
+    /// The file location option.
+    /// </value>
+    FileLocationOption FileLocationOption { get; }
+
     /// <summary>
     /// Sets the application name for cache directory paths.
     /// </summary>

--- a/src/Akavache.Sqlite3/AkavacheBuilderExtensions.cs
+++ b/src/Akavache.Sqlite3/AkavacheBuilderExtensions.cs
@@ -150,7 +150,12 @@ public static class AkavacheBuilderExtensions
         // Validate cache name to prevent path traversal attacks
         var validatedName = SecurityUtilities.ValidateCacheName(name, nameof(name));
 
-        var directory = builder.GetIsolatedCacheDirectory(validatedName);
+        // Determine the cache directory
+        var directory = builder.FileLocationOption switch
+        {
+            FileLocationOption.Legacy => builder.GetLegacyCacheDirectory(validatedName),
+            _ => builder.GetIsolatedCacheDirectory(validatedName),
+        };
         if (string.IsNullOrWhiteSpace(directory))
         {
             throw new InvalidOperationException("Failed to determine a valid cache directory.");


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Legacy file paths are not included

**What is the new behavior?**
<!-- If this is a feature change -->

Introduces the FileLocationOption enum to allow selection between default and legacy cache directory locations. Updates AkavacheBuilder, IAkavacheBuilder, and related initialization methods to support this option. Adjusts cache directory resolution logic in both core and Sqlite3 extensions to respect the selected file location option.


**What might this PR break?**

Defaults to V11 file locations

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

