### PR TITLE
Update dependencies, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
 
 <img alt="Akavache" src="https://raw.githubusercontent.com/reactiveui/styleguide/master/logo_akavache/main.png" width="150" />
 
-# Akavache V11.1: An Asynchronous Key-Value Store for Native Applications
+# Akavache: An Asynchronous Key-Value Store for Native Applications
 
 Akavache is an *asynchronous*, *persistent* (i.e., writes to disk) key-value store created for writing desktop and mobile applications in C#, based on SQLite3. Akavache is great for both storing important data (i.e., user settings) as well as cached local data that expires.
 
-## What's New in V11.1
+## What's New
 
-Akavache V11.1 introduces a new **Builder Pattern** for initialization, improved serialization support, and enhanced cross-serializer compatibility:
+Akavache V11.1 introduced a new **Builder Pattern** for initialization, improved serialization support, and enhanced cross-serializer compatibility:
 
 - 🏗️ **Builder Pattern**: New fluent API for configuring cache instances
 - 🔄 **Multiple Serializer Support**: Choose between System.Text.Json, Newtonsoft.Json, each with a BSON variant
@@ -32,7 +32,7 @@ Akavache V11.1 introduces a new **Builder Pattern** for initialization, improved
 
 ### Development History
 
-Akavache V11.1 represents a significant evolution in the library's architecture, developed through extensive testing and community feedback in our incubator project. The new features and improvements in V11.1 were first prototyped and battle-tested in the [ReactiveMarbles.CacheDatabase](https://github.com/reactivemarbles/CacheDatabase) repository, which served as an experimental ground for exploring new caching concepts and architectural patterns.
+Akavache V11.1+ represents a significant evolution in the library's architecture, developed through extensive testing and community feedback in our incubator project. The new features and improvements in V11.1 were first prototyped and battle-tested in the [ReactiveMarbles.CacheDatabase](https://github.com/reactivemarbles/CacheDatabase) repository, which served as an experimental ground for exploring new caching concepts and architectural patterns.
 
 **Key Development Milestones:**
 
@@ -48,8 +48,8 @@ This careful incubation process ensured that V11.1 delivers not just new feature
 ### 1. Install Packages
 
 ```xml
-<PackageReference Include="Akavache.Sqlite3" Version="11.1.*" />
-<PackageReference Include="Akavache.SystemTextJson" Version="11.1.*" />
+<PackageReference Include="Akavache.Sqlite3" Version="*" />
+<PackageReference Include="Akavache.SystemTextJson" Version="*" />
 ```
 
 ### 2. Initialize Akavache
@@ -142,57 +142,58 @@ await CacheDatabase.InMemory.InsertObject("current_session", sessionData);
 
 ## Installation
 
-Akavache V11.1 uses a modular package structure. Choose the packages that match your needs:
+Akavache uses a modular package structure. Choose the packages that match your needs:
 
 ### Core Package (In Memory only)
 ```xml
-<PackageReference Include="Akavache" Version="11.1.*" />
+<PackageReference Include="Akavache" Version="*" />
 ```
 
 ### Storage Backends (Choose One - Recommended)
 ```xml
 <!-- SQLite persistence (most common) -->
-<PackageReference Include="Akavache.Sqlite3" Version="11.1.*" />
+<PackageReference Include="Akavache.Sqlite3" Version="*" />
 
 <!-- Encrypted SQLite persistence -->
-<PackageReference Include="Akavache.EncryptedSqlite3" Version="11.1.*" />
+<PackageReference Include="Akavache.EncryptedSqlite3" Version="*" />
 ```
 
 ### Serializers (Choose One - Required)
 ```xml
 <!-- System.Text.Json (fastest, .NET native) -->
-<PackageReference Include="Akavache.SystemTextJson" Version="11.1.*" />
+<PackageReference Include="Akavache.SystemTextJson" Version="*" />
 
 <!-- Newtonsoft.Json (most compatible) -->
-<PackageReference Include="Akavache.NewtonsoftJson" Version="11.1.*" />
+<PackageReference Include="Akavache.NewtonsoftJson" Version="*" />
 ```
 
 ### Optional Extensions
 ```xml
 <!-- Image/Bitmap support -->
-<PackageReference Include="Akavache.Drawing" Version="11.1.*" />
+<PackageReference Include="Akavache.Drawing" Version="*" />
 
 <!-- Settings helpers -->
-<PackageReference Include="Akavache.Settings" Version="11.1.*" />
+<PackageReference Include="Akavache.Settings" Version="*" />
 ```
 
 ## Framework Support
 
-Akavache V11.1 supports:
+Akavache supports:
 
 - ✅ **.NET Framework 4.6.2/4.7.2** - Windows desktop applications
 - ✅ **.NET Standard 2.0** - Cross-platform libraries
 - ✅ **.NET 8.0** - Modern .NET applications
 - ✅ **.NET 9.0** - Latest .NET applications
-- ✅ **Mobile Targets** - `net9.0-android`, `net9.0-ios`, `net9.0-maccatalyst`
-- ✅ **Desktop Targets** - `net9.0-windows` (WinUI), `net9.0` (cross-platform)
+- ✅ **.NET 10.0** - Latest .NET applications
+- ✅ **Mobile Targets** - `net9.0-android`, `net9.0-ios`, `net9.0-maccatalyst`, `net10.0-android`, `net10.0-ios`, `net10.0-maccatalyst`
+- ✅ **Desktop Targets** - `net9.0-windows10.0.19041.0`, `net10.0-windows10.0.19041.0` (WinUI), `net9.0`, `net10.0` (cross-platform)
 
 ### Serializer Compatibility
 
-| Serializer | .NET Framework 4.6.2+ | .NET Standard 2.0 | .NET 8.0+ | Mobile | Performance |
+| Serializer | .NET Framework 4.6.2+ | .NET 8.0+ | Mobile | Performance |
 |------------|------------------------|-------------------|------------|--------|-------------|
-| **System.Text.Json** | ✅ Via NuGet | ✅ | ✅ | ✅ | **Fastest** |
-| **Newtonsoft.Json** | ✅ Built-in | ✅ | ✅ | ✅ | Compatible |
+| **System.Text.Json** | ✅ Via NuGet | ✅ | ✅ | **Fastest** |
+| **Newtonsoft.Json** | ✅ Built-in | ✅ | ✅ | Compatible |
 
 **Recommendation**: Use **System.Text.Json** for new projects for best performance. Use **Newtonsoft.Json** when migrating from older Akavache versions or when you need maximum compatibility.
 

--- a/src/Akavache.Core/Akavache.csproj
+++ b/src/Akavache.Core/Akavache.csproj
@@ -12,9 +12,6 @@
     <PackageReference Include="Splat.Builder" />
     <PackageReference Include="System.Reactive" />
     <PackageReference Include="sqlite-net-pcl" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
-    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net481'" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,10 +29,10 @@
     <LangVersion>preview</LangVersion>
     
     <!-- Base TFMs that build on any OS (but excluding net9.0 for Windows to avoid conflicts) -->
-    <AkavacheBaseTargets>netstandard2.0;net8.0;net9.0;net10.0</AkavacheBaseTargets>
+    <AkavacheBaseTargets>net8.0;net9.0;net10.0</AkavacheBaseTargets>
 
     <!-- Windows-specific desktop TFMs (includes Windows-specific .NET 9) -->
-    <AkavacheWindowsDesktopTargets>net462;net472;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</AkavacheWindowsDesktopTargets>
+    <AkavacheWindowsDesktopTargets>net462;net472;net481;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</AkavacheWindowsDesktopTargets>
 
     <!-- Mobile TFMs separated by platform -->
     <AkavacheMobileAndroidTargets>net9.0-android;net10.0-android</AkavacheMobileAndroidTargets>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,17 +5,17 @@
   </PropertyGroup>
   <!-- Version groups for packages that share the same version -->
   <PropertyGroup>
-    <MicrosoftExtensionsVersion>10.0.0</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion>10.0.1</MicrosoftExtensionsVersion>
     <SqlitePclRawVersion>2.1.11</SqlitePclRawVersion>
     <SqliteNetVersion>1.9.172</SqliteNetVersion>
-    <SplatVersion>17.1.1</SplatVersion>
-    <ReactiveUIVersion>22.2.1</ReactiveUIVersion>
+    <SplatVersion>19.1.1</SplatVersion>
+    <ReactiveUIVersion>22.3.1</ReactiveUIVersion>
   </PropertyGroup>
   <!-- All projects -->
   <ItemGroup>
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
     <PackageVersion Include="stylecop.analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.14.1" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
   </ItemGroup>
   <!-- Non-test projects only -->
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
@@ -46,7 +46,7 @@
     <PackageVersion Include="Splat.Drawing" Version="$(SplatVersion)" />
   </ItemGroup>
   <!-- .NET Framework-specific packages -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net481'">
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <!-- Test-specific packages -->
@@ -56,7 +56,7 @@
   </ItemGroup>
   <!-- Benchmark packages -->
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.6" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="Akavache.Sqlite3" Version="11.4.1" />
     <PackageVersion Include="Akavache" Version="11.4.1" />
   </ItemGroup>

--- a/src/Samples/AkavacheTodoMaui/AkavacheTodoMaui.csproj
+++ b/src/Samples/AkavacheTodoMaui/AkavacheTodoMaui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android</TargetFrameworks>
+    <TargetFrameworks>net10.0-android</TargetFrameworks>
     <!--<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>-->
 
     <OutputType>Exe</OutputType>

--- a/src/Samples/AkavacheTodoWpf/AkavacheTodoWpf.csproj
+++ b/src/Samples/AkavacheTodoWpf/AkavacheTodoWpf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

NetStandard2.0 included

**What is the new behavior?**
<!-- If this is a feature change -->

Updated target frameworks in sample projects and build props to .NET 10.0 where applicable. 
Upgraded package versions for Splat, ReactiveUI, Microsoft.Extensions, Roslynator.Analyzers, and BenchmarkDotNet. 
Improved README to reflect new framework support and generalized version references. 
Added net481 support for System.Net.Http.
These changes ensure compatibility with the latest .NET versions and keep dependencies current.

**What might this PR break?**

Removes NetStandard2.0

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

