### PR TITLE
fix: Add WithLegacyFileLocation() for V10→V11 migration

### DIFF
--- a/docs/migration-v10-to-v11.md
+++ b/docs/migration-v10-to-v11.md
@@ -167,9 +167,12 @@ BlobCache.SecureFileStorage = new EncryptedBlobStorage("password");
 AppBuilder.CreateSplatBuilder()
     .WithAkavache<SystemJsonSerializer>(builder =>
         builder.WithApplicationName("MySecureApp")
+               .WithLegacyFileLocation()          // Required to find V10 secure databases
                .WithEncryptedSqliteProvider()
                .WithSqliteDefaults("password"));
 ```
+
+> **Important:** The `WithLegacyFileLocation()` call is critical when migrating from V10. Without it, V11 will create new databases in isolated storage directories, and your existing secure cache data will not be found.
 
 ### Scenario 3: Custom Storage Locations
 
@@ -367,9 +370,34 @@ AppBuilder.CreateSplatBuilder()
 ```
 
 #### 3. Data not found after migration
+
+V11 uses isolated storage directories by default, which differ from V10's file locations. To read existing V10 data, you **must** use `WithLegacyFileLocation()` so that V11 looks for database files in the same directories V10 used:
+
 ```csharp
-// Check if application name changed
-builder.WithApplicationName("SameAsV10App") // Must match V10 app name
+// ✅ CORRECT - Use legacy file locations to find V10 databases
+AppBuilder.CreateSplatBuilder()
+    .WithAkavacheCacheDatabase<NewtonsoftBsonSerializer>(builder =>
+        builder.WithApplicationName("SameAsV10App") // Must match V10 app name
+               .WithLegacyFileLocation()             // Required to find V10 databases
+               .WithSqliteProvider()
+               .WithSqliteDefaults());
+
+// ⚠️ WRONG - Without WithLegacyFileLocation(), V11 creates new empty databases
+// in isolated storage and your V10 data will not be found
+builder.WithApplicationName("SameAsV10App")
+       .WithSqliteProvider()
+       .WithSqliteDefaults();
+```
+
+V11 automatically reads data from V10's `CacheElement` table when a key is not found in the new `CacheEntry` table. This backward-compatible read happens transparently — no manual data migration is needed. Just ensure V11 can find the database files by using `WithLegacyFileLocation()`.
+
+You can also pass `FileLocationOption.Legacy` directly when using `CacheDatabase.Initialize`:
+
+```csharp
+CacheDatabase.Initialize<NewtonsoftBsonSerializer>(
+    configure: builder => builder.WithSqliteProvider().WithSqliteDefaults(),
+    applicationName: "SameAsV10App",
+    fileLocationOption: FileLocationOption.Legacy);
 ```
 
 ### Migration Checklist
@@ -377,6 +405,7 @@ builder.WithApplicationName("SameAsV10App") // Must match V10 app name
 - [ ] Updated package references
 - [ ] Replaced initialization code
 - [ ] Added explicit provider initialization
+- [ ] **Used `WithLegacyFileLocation()` to find existing V10 databases**
 - [ ] Tested existing data access
 - [ ] Verified new data storage
 - [ ] Updated DI container registration (if applicable)

--- a/src/Akavache.Core/Core/AkavacheBuilder.cs
+++ b/src/Akavache.Core/Core/AkavacheBuilder.cs
@@ -135,6 +135,13 @@ internal class AkavacheBuilder : IAkavacheBuilder
     internal static Dictionary<string, ISettingsStorage?>? SettingsStores { get; set; } = [];
 
     /// <inheritdoc />
+    public IAkavacheBuilder WithLegacyFileLocation()
+    {
+        _fileLocationOption = FileLocationOption.Legacy;
+        return this;
+    }
+
+    /// <inheritdoc />
     public IAkavacheBuilder WithApplicationName(string? applicationName)
     {
         if (string.IsNullOrWhiteSpace(applicationName))

--- a/src/Akavache.Core/IAkavacheBuilder.cs
+++ b/src/Akavache.Core/IAkavacheBuilder.cs
@@ -90,6 +90,14 @@ public interface IAkavacheBuilder : IAkavacheInstance
         where T : ISerializer;
 
     /// <summary>
+    /// Configures the builder to use legacy file locations for cache directories.
+    /// This is required when migrating from V10 to V11 so that V11 can find and read
+    /// the existing V10 database files.
+    /// </summary>
+    /// <returns>The builder instance for fluent configuration.</returns>
+    IAkavacheBuilder WithLegacyFileLocation();
+
+    /// <summary>
     /// Sets the forced DateTime kind for serialization operations.
     /// </summary>
     /// <param name="kind">The DateTime kind to use for all DateTime serialization.</param>

--- a/src/Akavache.Sqlite3/AkavacheBuilderExtensions.cs
+++ b/src/Akavache.Sqlite3/AkavacheBuilderExtensions.cs
@@ -166,6 +166,12 @@ public static class AkavacheBuilderExtensions
             throw new InvalidOperationException("Failed to determine a valid cache directory.");
         }
 
+        // Ensure the cache directory exists (legacy paths may not be pre-created)
+        if (!Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
         var filePath = Path.Combine(directory, $"{validatedName}.db");
 
         // Resolve the serializer from the service locator to ensure proper lifecycle management

--- a/src/Akavache.Tests/LegacyFileLocationTests.cs
+++ b/src/Akavache.Tests/LegacyFileLocationTests.cs
@@ -1,0 +1,388 @@
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Akavache.Core;
+using Akavache.Sqlite3;
+using Akavache.SystemTextJson;
+
+namespace Akavache.Tests;
+
+/// <summary>
+/// Tests for WithLegacyFileLocation builder method and FileLocationOption behavior.
+/// Validates that V10→V11 migration scenarios work correctly when using legacy file locations.
+/// </summary>
+[Category("Akavache")]
+public class LegacyFileLocationTests
+{
+    /// <summary>
+    /// Verifies that WithLegacyFileLocation sets the FileLocationOption to Legacy.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WithLegacyFileLocation_SetsFileLocationOptionToLegacy()
+    {
+        // Arrange
+        var builder = CacheDatabase.CreateBuilder();
+
+        // Act
+        builder.WithLegacyFileLocation();
+
+        // Assert
+        await Assert.That(builder.FileLocationOption).IsEqualTo(FileLocationOption.Legacy);
+    }
+
+    /// <summary>
+    /// Verifies that the default FileLocationOption is Default.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task CreateBuilder_DefaultFileLocationOption_IsDefault()
+    {
+        // Act
+        var builder = CacheDatabase.CreateBuilder();
+
+        // Assert
+        await Assert.That(builder.FileLocationOption).IsEqualTo(FileLocationOption.Default);
+    }
+
+    /// <summary>
+    /// Verifies that CreateBuilder with explicit Legacy option sets it correctly.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task CreateBuilder_WithLegacyOption_SetsFileLocationOptionToLegacy()
+    {
+        // Act
+        var builder = CacheDatabase.CreateBuilder(FileLocationOption.Legacy);
+
+        // Assert
+        await Assert.That(builder.FileLocationOption).IsEqualTo(FileLocationOption.Legacy);
+    }
+
+    /// <summary>
+    /// Verifies that WithLegacyFileLocation returns the builder for fluent chaining.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WithLegacyFileLocation_ReturnsSameBuilder_ForFluentChaining()
+    {
+        // Arrange
+        var builder = CacheDatabase.CreateBuilder();
+
+        // Act
+        var result = builder.WithLegacyFileLocation();
+
+        // Assert
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    /// <summary>
+    /// Verifies that WithLegacyFileLocation can be chained with other builder methods.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WithLegacyFileLocation_CanBeChainedWithOtherMethods()
+    {
+        // Arrange & Act
+        var builder = CacheDatabase.CreateBuilder()
+            .WithApplicationName("TestApp")
+            .WithLegacyFileLocation()
+            .WithSerializer<SystemJsonSerializer>();
+
+        // Assert
+        using (Assert.Multiple())
+        {
+            await Assert.That(builder.FileLocationOption).IsEqualTo(FileLocationOption.Legacy);
+            await Assert.That(builder.ApplicationName).IsEqualTo("TestApp");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that legacy file location produces different cache directories than the default.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task LegacyFileLocation_ProducesDifferentPath_ThanDefault()
+    {
+        // Arrange
+        var appName = "LegacyPathTest";
+
+        var defaultBuilder = CacheDatabase.CreateBuilder()
+            .WithApplicationName(appName)
+            .WithSerializer<SystemJsonSerializer>();
+
+        var legacyBuilder = CacheDatabase.CreateBuilder(FileLocationOption.Legacy)
+            .WithApplicationName(appName)
+            .WithSerializer<SystemJsonSerializer>();
+
+        // Act
+        var defaultPath = defaultBuilder.GetIsolatedCacheDirectory("UserAccount");
+        var legacyPath = legacyBuilder.GetLegacyCacheDirectory("UserAccount");
+
+        // Assert - the paths should be different (isolated storage vs legacy app data)
+        await Assert.That(defaultPath).IsNotNull();
+        await Assert.That(legacyPath).IsNotNull();
+        await Assert.That(defaultPath).IsNotEqualTo(legacyPath);
+    }
+
+    /// <summary>
+    /// Verifies that the legacy directory for UserAccount points to the expected location.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task GetLegacyCacheDirectory_UserAccount_ContainsApplicationName()
+    {
+        // Arrange
+        var appName = "LegacyDirTest";
+        var builder = CacheDatabase.CreateBuilder(FileLocationOption.Legacy)
+            .WithApplicationName(appName)
+            .WithSerializer<SystemJsonSerializer>();
+
+        // Act
+        var legacyPath = builder.GetLegacyCacheDirectory("UserAccount");
+
+        // Assert
+        await Assert.That(legacyPath).IsNotNull();
+        await Assert.That(legacyPath!).Contains(appName);
+    }
+
+    /// <summary>
+    /// Verifies that legacy Secure directory points to SecretCache subdirectory.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task GetLegacyCacheDirectory_Secure_ContainsSecretCache()
+    {
+        // Arrange
+        var appName = "LegacySecureDirTest";
+        var builder = CacheDatabase.CreateBuilder(FileLocationOption.Legacy)
+            .WithApplicationName(appName)
+            .WithSerializer<SystemJsonSerializer>();
+
+        // Act
+        var legacyPath = builder.GetLegacyCacheDirectory("Secure");
+
+        // Assert
+        await Assert.That(legacyPath).IsNotNull();
+        await Assert.That(legacyPath!).Contains("SecretCache");
+    }
+
+    /// <summary>
+    /// Verifies that legacy LocalMachine directory points to BlobCache subdirectory.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task GetLegacyCacheDirectory_LocalMachine_ContainsBlobCache()
+    {
+        // Arrange
+        var appName = "LegacyLocalMachineDirTest";
+        var builder = CacheDatabase.CreateBuilder(FileLocationOption.Legacy)
+            .WithApplicationName(appName)
+            .WithSerializer<SystemJsonSerializer>();
+
+        // Act
+        var legacyPath = builder.GetLegacyCacheDirectory("LocalMachine");
+
+        // Assert
+        await Assert.That(legacyPath).IsNotNull();
+        await Assert.That(legacyPath!).Contains("BlobCache");
+    }
+
+    /// <summary>
+    /// Verifies that Initialize with FileLocationOption.Legacy creates caches at legacy paths.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Initialize_WithLegacyFileLocation_CreatesCachesAtLegacyPaths()
+    {
+        // Arrange
+        var testAppName = $"LegacyInitTest_{Guid.NewGuid():N}";
+        Akavache.Sqlite3.AkavacheBuilderExtensions.ResetSqliteProviderForTests();
+
+        try
+        {
+            // Act
+            CacheDatabase.Initialize<SystemJsonSerializer>(
+                configure: builder =>
+                {
+                    builder.WithSqliteProvider();
+                    builder.WithSqliteDefaults();
+                },
+                applicationName: testAppName,
+                fileLocationOption: FileLocationOption.Legacy);
+
+            // Assert - caches should be initialized
+            using (Assert.Multiple())
+            {
+                await Assert.That(CacheDatabase.UserAccount).IsNotNull();
+                await Assert.That(CacheDatabase.LocalMachine).IsNotNull();
+                await Assert.That(CacheDatabase.Secure).IsNotNull();
+                await Assert.That(CacheDatabase.InMemory).IsNotNull();
+            }
+        }
+        finally
+        {
+            await CacheDatabase.ResetForTestsAsync();
+            Akavache.Sqlite3.AkavacheBuilderExtensions.ResetSqliteProviderForTests();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that WithLegacyFileLocation in builder chain initializes caches correctly.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WithLegacyFileLocation_InBuilderChain_InitializesCachesCorrectly()
+    {
+        // Arrange
+        var testAppName = $"LegacyBuilderChainTest_{Guid.NewGuid():N}";
+        Akavache.Sqlite3.AkavacheBuilderExtensions.ResetSqliteProviderForTests();
+
+        try
+        {
+            // Act - using the new fluent builder method
+            CacheDatabase.Initialize<SystemJsonSerializer>(
+                configure: builder =>
+                {
+                    builder.WithLegacyFileLocation()
+                           .WithSqliteProvider()
+                           .WithSqliteDefaults();
+                },
+                applicationName: testAppName);
+
+            // Assert - caches should be initialized and functional
+            using (Assert.Multiple())
+            {
+                await Assert.That(CacheDatabase.UserAccount).IsNotNull();
+                await Assert.That(CacheDatabase.LocalMachine).IsNotNull();
+                await Assert.That(CacheDatabase.Secure).IsNotNull();
+                await Assert.That(CacheDatabase.InMemory).IsNotNull();
+            }
+        }
+        finally
+        {
+            await CacheDatabase.ResetForTestsAsync();
+            Akavache.Sqlite3.AkavacheBuilderExtensions.ResetSqliteProviderForTests();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that data can be written and read with legacy file locations.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task LegacyFileLocation_CanWriteAndReadData()
+    {
+        // Arrange
+        var testAppName = $"LegacyDataTest_{Guid.NewGuid():N}";
+        Akavache.Sqlite3.AkavacheBuilderExtensions.ResetSqliteProviderForTests();
+
+        try
+        {
+            CacheDatabase.Initialize<SystemJsonSerializer>(
+                configure: builder =>
+                {
+                    builder.WithLegacyFileLocation()
+                           .WithSqliteProvider()
+                           .WithSqliteDefaults();
+                },
+                applicationName: testAppName);
+
+            // Act - write data
+            var testKey = "test-key";
+            var testValue = "test-value";
+            await CacheDatabase.UserAccount!.InsertObject(testKey, testValue);
+
+            // Assert - read data back
+            var result = await CacheDatabase.UserAccount.GetObject<string>(testKey);
+            await Assert.That(result).IsEqualTo(testValue);
+        }
+        finally
+        {
+            await CacheDatabase.ResetForTestsAsync();
+            Akavache.Sqlite3.AkavacheBuilderExtensions.ResetSqliteProviderForTests();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that SettingsCachePath uses legacy directory when legacy option is set.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task SettingsCachePath_WithLegacyOption_UsesLegacyDirectory()
+    {
+        // Arrange
+        var appName = "LegacySettingsPathTest";
+
+        var defaultBuilder = CacheDatabase.CreateBuilder()
+            .WithApplicationName(appName)
+            .WithSerializer<SystemJsonSerializer>();
+
+        var legacyBuilder = CacheDatabase.CreateBuilder(FileLocationOption.Legacy)
+            .WithApplicationName(appName)
+            .WithSerializer<SystemJsonSerializer>();
+
+        // Act
+        var defaultPath = defaultBuilder.SettingsCachePath;
+        var legacyPath = legacyBuilder.SettingsCachePath;
+
+        // Assert - paths should be different
+        await Assert.That(defaultPath).IsNotNull();
+        await Assert.That(legacyPath).IsNotNull();
+        await Assert.That(defaultPath).IsNotEqualTo(legacyPath);
+    }
+
+    /// <summary>
+    /// Verifies that data written with legacy location can be read back after re-initialization.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task LegacyFileLocation_DataPersistsAcrossReinitialization()
+    {
+        // Arrange
+        var testAppName = $"LegacyPersistTest_{Guid.NewGuid():N}";
+        var testKey = "persist-key";
+        var testValue = "persist-value";
+        Akavache.Sqlite3.AkavacheBuilderExtensions.ResetSqliteProviderForTests();
+
+        try
+        {
+            // Act - write data with first initialization
+            CacheDatabase.Initialize<SystemJsonSerializer>(
+                configure: builder =>
+                {
+                    builder.WithLegacyFileLocation()
+                           .WithSqliteProvider()
+                           .WithSqliteDefaults();
+                },
+                applicationName: testAppName);
+
+            await CacheDatabase.UserAccount!.InsertObject(testKey, testValue);
+            await CacheDatabase.UserAccount.Flush();
+
+            // Reinitialize
+            await CacheDatabase.ResetForTestsAsync();
+            Akavache.Sqlite3.AkavacheBuilderExtensions.ResetSqliteProviderForTests();
+
+            CacheDatabase.Initialize<SystemJsonSerializer>(
+                configure: builder =>
+                {
+                    builder.WithLegacyFileLocation()
+                           .WithSqliteProvider()
+                           .WithSqliteDefaults();
+                },
+                applicationName: testAppName);
+
+            // Assert - data should still be there
+            var result = await CacheDatabase.UserAccount!.GetObject<string>(testKey);
+            await Assert.That(result).IsEqualTo(testValue);
+        }
+        finally
+        {
+            await CacheDatabase.ResetForTestsAsync();
+            Akavache.Sqlite3.AkavacheBuilderExtensions.ResetSqliteProviderForTests();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Migrating from Akavache V10 to V11 could silently lose all cached data because V11 uses isolated storage directories by default, which differ from V10's file locations. This PR makes migration straightforward by:

- **Adding `WithLegacyFileLocation()`** — a new fluent builder method that tells V11 to use the same cache directories V10 used, so your existing databases are found automatically
- **Fixing directory creation** — legacy cache directories weren't being created when they didn't exist, causing `SQLiteException: CannotOpen` on first use
- **Updating migration docs** — the migration guide now documents `WithLegacyFileLocation()` as a required step, with examples for both standard and secure/encrypted caches

### How to migrate from V10 to V11

```csharp
// Just add .WithLegacyFileLocation() to your builder chain:
AppBuilder.CreateSplatBuilder()
    .WithAkavacheCacheDatabase<NewtonsoftBsonSerializer>(builder =>
        builder.WithApplicationName("YourAppName")
               .WithLegacyFileLocation()    // ← finds V10 databases
               .WithSqliteProvider()
               .WithSqliteDefaults());
```

V11 automatically reads data from V10's `CacheElement` table when a key is not found in the new `CacheEntry` table — no manual data migration needed.

Fixes #1140, Fixes #1138

## Test plan

- [x] 14 new tests in `LegacyFileLocationTests.cs` covering builder API, path behavior, data read/write, and persistence across reinitialization
- [x] All 1652 existing tests pass (0 failures)
- [x] All 46 settings tests pass