### PR TITLE
perf: allocation reduction sweep across Rx, SQLite and serializer hot paths

### DIFF
--- a/src/Akavache.Core/AkavacheBuilderExtensions.cs
+++ b/src/Akavache.Core/AkavacheBuilderExtensions.cs
@@ -408,32 +408,61 @@ public static class AkavacheBuilderExtensions
         });
 
     /// <summary>
-    /// Splits the full path of the supplied <see cref="DirectoryInfo"/> into its individual path components.
+    /// Splits the full path of the supplied <see cref="DirectoryInfo"/> into its individual
+    /// path components in root-down order. Uses <c>yield return</c> so the common
+    /// <see cref="Enumerable.Aggregate{TSource}"/> consumer never sees a materialised list.
     /// </summary>
     /// <param name="directoryInfo">The directory whose full path will be split.</param>
     /// <returns>The ordered path components, beginning with the root.</returns>
     internal static IEnumerable<string> SplitFullPath(this DirectoryInfo directoryInfo)
     {
-        var root = Path.GetPathRoot(directoryInfo.FullName);
-        List<string> components = [];
-        for (var path = directoryInfo.FullName; path != root && path is not null; path = Path.GetDirectoryName(path))
+        var fullName = directoryInfo.FullName;
+        var root = Path.GetPathRoot(fullName);
+
+        // Walk once from leaf to root to know the depth — cheap (just string comparisons +
+        // GetDirectoryName) and lets us pre-size a stack-like char-sized cursor below.
+        var depth = 0;
+        for (var path = fullName; path != root && path is not null; path = Path.GetDirectoryName(path))
         {
             var filename = Path.GetFileName(path);
-            if (string.IsNullOrEmpty(filename))
+            if (!string.IsNullOrEmpty(filename))
             {
-                continue;
+                depth++;
+            }
+        }
+
+        return SplitFullPathIterator(fullName, root, depth);
+
+        static IEnumerable<string> SplitFullPathIterator(string fullName, string? root, int depth)
+        {
+            if (root is not null)
+            {
+                yield return root;
             }
 
-            components.Add(filename);
-        }
+            if (depth == 0)
+            {
+                yield break;
+            }
 
-        if (root is not null)
-        {
-            components.Add(root);
-        }
+            // Second pass materialises components leaf-to-root into a local buffer so we can
+            // emit them root-to-leaf without the old List allocation + Reverse step.
+            var components = new string[depth];
+            var index = depth - 1;
+            for (var path = fullName; path != root && path is not null && index >= 0; path = Path.GetDirectoryName(path))
+            {
+                var filename = Path.GetFileName(path);
+                if (!string.IsNullOrEmpty(filename))
+                {
+                    components[index--] = filename;
+                }
+            }
 
-        components.Reverse();
-        return components;
+            for (var i = 0; i < components.Length; i++)
+            {
+                yield return components[i];
+            }
+        }
     }
 
 #if IOS || MACCATALYST

--- a/src/Akavache.Core/CacheDatabase.cs
+++ b/src/Akavache.Core/CacheDatabase.cs
@@ -88,7 +88,7 @@ public static class CacheDatabase
     {
         if (!IsInitialized || Builder == null)
         {
-            return Observable.Return(Unit.Default);
+            return CachedObservables.UnitDefault;
         }
 
         List<IObservable<Unit>> shutdownTasks = [];
@@ -100,9 +100,9 @@ public static class CacheDatabase
             {
                 List<Task> tasks = [.. AkavacheBuilder.BlobCaches
                 .Where(static cachePair => cachePair.Value != null)
-                .Select(static async cache => await cache.Value!.DisposeAsync())];
-                await Task.WhenAll(tasks);
-            }).Select(static _ => Unit.Default);
+                .Select(static async cache => await cache.Value!.DisposeAsync().ConfigureAwait(false))];
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }).SelectUnit();
             shutdownTasks.Add(shutdownSettingsBlobs);
         }
 
@@ -112,18 +112,18 @@ public static class CacheDatabase
             {
                 List<Task> tasks = [.. AkavacheBuilder.SettingsStores
                 .Where(static cachePair => cachePair.Value != null)
-                .Select(static async cache => await cache.Value!.DisposeAsync())];
-                await Task.WhenAll(tasks);
-            }).Select(static _ => Unit.Default);
+                .Select(static async cache => await cache.Value!.DisposeAsync().ConfigureAwait(false))];
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }).SelectUnit();
             shutdownTasks.Add(shutdownSettingsStores);
         }
 
         try
         {
-            shutdownTasks.Add(Builder.UserAccount?.Flush() ?? Observable.Return(Unit.Default));
-            shutdownTasks.Add(Builder.LocalMachine?.Flush() ?? Observable.Return(Unit.Default));
-            shutdownTasks.Add(Builder.Secure?.Flush() ?? Observable.Return(Unit.Default));
-            shutdownTasks.Add(Builder.InMemory?.Flush() ?? Observable.Return(Unit.Default));
+            shutdownTasks.Add(Builder.UserAccount?.Flush() ?? CachedObservables.UnitDefault);
+            shutdownTasks.Add(Builder.LocalMachine?.Flush() ?? CachedObservables.UnitDefault);
+            shutdownTasks.Add(Builder.Secure?.Flush() ?? CachedObservables.UnitDefault);
+            shutdownTasks.Add(Builder.InMemory?.Flush() ?? CachedObservables.UnitDefault);
         }
         catch (Exception ex)
         {

--- a/src/Akavache.Core/CacheEntry.cs
+++ b/src/Akavache.Core/CacheEntry.cs
@@ -14,6 +14,35 @@ namespace Akavache;
 public class CacheEntry : IEquatable<CacheEntry>
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="CacheEntry"/> class.
+    /// Required by sqlite-net's ORM which materialises rows via reflection.
+    /// </summary>
+    public CacheEntry()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CacheEntry"/> class with all fields populated.
+    /// Preferred over the parameterless form at construction sites in the library: on older runtimes
+    /// (notably net462) the JIT produces tighter codegen for a single ctor + field writes than for
+    /// a <c>new() { … }</c> initializer that expands to a parameterless ctor followed by property
+    /// setters.
+    /// </summary>
+    /// <param name="id">The cache entry's unique key.</param>
+    /// <param name="typeName">Optional type discriminator, stored alongside the row.</param>
+    /// <param name="value">The serialized payload bytes.</param>
+    /// <param name="createdAt">The instant at which the entry was created.</param>
+    /// <param name="expiresAt">Optional absolute expiration time. Null means "never expires".</param>
+    public CacheEntry(string? id, string? typeName, byte[]? value, DateTimeOffset createdAt, DateTimeOffset? expiresAt)
+    {
+        Id = id;
+        TypeName = typeName;
+        Value = value;
+        CreatedAt = createdAt;
+        ExpiresAt = expiresAt;
+    }
+
+    /// <summary>
     /// Gets or sets the unique identifier for the cache entry.
     /// </summary>
     [PrimaryKey]
@@ -75,12 +104,13 @@ public class CacheEntry : IEquatable<CacheEntry>
     }
 
     /// <summary>
-    /// Checks if two byte arrays are equal.
+    /// Checks whether two byte arrays contain equal data, treating two <see langword="null"/>
+    /// buffers as equal.
     /// </summary>
     /// <param name="left">The first byte array.</param>
     /// <param name="right">The second byte array.</param>
     /// <returns>True if the byte arrays are equal.</returns>
-    private static bool ValueEquals(byte[]? left, byte[]? right) =>
+    internal static bool ValueEquals(byte[]? left, byte[]? right) =>
         ReferenceEquals(left, right) ||
         (left is not null && right is not null && left.AsSpan().SequenceEqual(right));
 }

--- a/src/Akavache.Core/Core/AkavacheBuilder.cs
+++ b/src/Akavache.Core/Core/AkavacheBuilder.cs
@@ -346,7 +346,7 @@ internal class AkavacheBuilder : IAkavacheBuilder
         public void Dispose() => inner.Dispose();
 
         /// <inheritdoc />
-        public async ValueTask DisposeAsync() => await inner.DisposeAsync();
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
 
         /// <inheritdoc />
         public IObservable<Unit> Flush() => inner.Flush();

--- a/src/Akavache.Core/Core/CachedObservables.cs
+++ b/src/Akavache.Core/Core/CachedObservables.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Akavache.Core;
+
+/// <summary>
+/// Shared, cached observable singletons for frequently emitted trivial values.
+/// Rx.NET's <see cref="Observable.Return{TResult}(TResult)"/> allocates a new
+/// <c>ScalarObservable</c> on every call, so hot paths that emit <see cref="Unit.Default"/>
+/// as a no-op success signal (e.g. <c>Flush</c>, bulk <c>Insert</c>, <c>Invalidate</c>)
+/// allocate once per call. Routing through these cached instances is semantically
+/// identical and allocation-free.
+/// </summary>
+internal static class CachedObservables
+{
+    /// <summary>A cached <see cref="IObservable{T}"/> that synchronously emits a single
+    /// <see cref="Unit.Default"/> and completes. Use anywhere the library currently
+    /// calls <c>Observable.Return(Unit.Default)</c> as a success signal.</summary>
+    public static readonly IObservable<Unit> UnitDefault = Observable.Return(Unit.Default);
+}

--- a/src/Akavache.Core/Core/KeyMetadata.NonGeneric.cs
+++ b/src/Akavache.Core/Core/KeyMetadata.NonGeneric.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Akavache.Core;
+
+/// <summary>
+/// Non-generic companion holding the pure per-<see cref="Type"/> reflection logic used by
+/// <see cref="KeyMetadata{T}"/>. Exposed as internal statics so both branches of the null-fallback
+/// logic (null <see cref="Type.FullName"/> and null assembly simple name) can be exercised
+/// directly against dynamically-constructed types in unit tests.
+/// </summary>
+internal static class KeyMetadata
+{
+    /// <summary>
+    /// Returns <paramref name="type"/>'s <see cref="Type.FullName"/>, falling back to
+    /// the short type name for types where the runtime reports a null full name
+    /// (e.g. generic type parameters, certain emitted types).
+    /// </summary>
+    /// <param name="type">The type to probe.</param>
+    /// <returns>The full name, or short name when the full name is null.</returns>
+    internal static string BuildFullName(Type type) => type.FullName ?? type.Name;
+
+    /// <summary>
+    /// Returns <c><paramref name="type"/>.Assembly.GetName().Name + "." + <paramref name="type"/>.Name</c>,
+    /// collapsing to just the short type name when the assembly's simple name is null
+    /// (e.g. types defined in a dynamically-emitted assembly with a nameless manifest).
+    /// </summary>
+    /// <param name="type">The type to probe.</param>
+    /// <returns>The assembly-qualified short name, or just the short name when the assembly has no simple name.</returns>
+    internal static string BuildAssemblyQualifiedShortName(Type type) =>
+        type.Assembly.GetName().Name is { } asmName
+            ? asmName + "." + type.Name
+            : type.Name;
+}

--- a/src/Akavache.Core/Core/KeyMetadata.cs
+++ b/src/Akavache.Core/Core/KeyMetadata.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Akavache.Core;
+
+/// <summary>
+/// Per-type reflection-string cache used by <see cref="UniversalSerializer"/>'s key-candidate
+/// search. Each string is materialised exactly once per closed generic instantiation and then
+/// served directly from the static fields. Avoids walking
+/// <see cref="Type.FullName"/>, the short type name, and the assembly simple name on every
+/// cache lookup.
+/// </summary>
+/// <typeparam name="T">The value type whose reflection strings are being cached.</typeparam>
+internal static class KeyMetadata<T>
+{
+    /// <summary>Cached <c>typeof(T).FullName</c> (or <c>typeof(T).Name</c> when <see cref="Type.FullName"/> is null).</summary>
+    public static readonly string FullName = typeof(T).FullName ?? typeof(T).Name;
+
+    /// <summary>Cached <c>typeof(T).Name</c>.</summary>
+    public static readonly string Name = typeof(T).Name;
+
+    /// <summary>Cached <c>Assembly.Name + '.' + typeof(T).Name</c>, matching the original
+    /// third-form prefix built by <see cref="UniversalSerializer"/>. If the assembly name is
+    /// null it collapses to just the short type name.</summary>
+    public static readonly string AssemblyQualifiedShortName =
+        typeof(T).Assembly.GetName().Name is { } asmName
+            ? asmName + "." + typeof(T).Name
+            : typeof(T).Name;
+}

--- a/src/Akavache.Core/Core/KeyMetadata.cs
+++ b/src/Akavache.Core/Core/KeyMetadata.cs
@@ -15,7 +15,7 @@ namespace Akavache.Core;
 internal static class KeyMetadata<T>
 {
     /// <summary>Cached <c>typeof(T).FullName</c> (or <c>typeof(T).Name</c> when <see cref="Type.FullName"/> is null).</summary>
-    public static readonly string FullName = typeof(T).FullName ?? typeof(T).Name;
+    public static readonly string FullName = KeyMetadata.BuildFullName(typeof(T));
 
     /// <summary>Cached <c>typeof(T).Name</c>.</summary>
     public static readonly string Name = typeof(T).Name;
@@ -23,8 +23,5 @@ internal static class KeyMetadata<T>
     /// <summary>Cached <c>Assembly.Name + '.' + typeof(T).Name</c>, matching the original
     /// third-form prefix built by <see cref="UniversalSerializer"/>. If the assembly name is
     /// null it collapses to just the short type name.</summary>
-    public static readonly string AssemblyQualifiedShortName =
-        typeof(T).Assembly.GetName().Name is { } asmName
-            ? asmName + "." + typeof(T).Name
-            : typeof(T).Name;
+    public static readonly string AssemblyQualifiedShortName = KeyMetadata.BuildAssemblyQualifiedShortName(typeof(T));
 }

--- a/src/Akavache.Core/Core/ObservableUnitExtensions.cs
+++ b/src/Akavache.Core/Core/ObservableUnitExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Akavache.Core;
+
+/// <summary>
+/// Normalisation helpers for <see cref="Unit"/>-valued observable pipelines. Centralises
+/// the "discard incoming emissions and signal <see cref="Unit.Default"/>" pattern that
+/// previously appeared inline as <c>.Select(static _ =&gt; Unit.Default)</c> across the
+/// library. Perf is identical (both forms end up with a compiler-cached static delegate),
+/// the value is readability and a single point of change.
+/// </summary>
+internal static class ObservableUnitExtensions
+{
+    /// <summary>
+    /// Projects every emission of <paramref name="source"/> onto <see cref="Unit.Default"/>,
+    /// producing an <see cref="IObservable{T}"/> of <see cref="Unit"/>. Equivalent to
+    /// <c>source.Select(static _ =&gt; Unit.Default)</c> but clearer at the call site.
+    /// </summary>
+    /// <typeparam name="T">The element type of the source observable (ignored).</typeparam>
+    /// <param name="source">The observable whose emissions should be normalised to <see cref="Unit.Default"/>.</param>
+    /// <returns>An observable that emits <see cref="Unit.Default"/> once per emission of <paramref name="source"/>.</returns>
+    public static IObservable<Unit> SelectUnit<T>(this IObservable<T> source) =>
+        source.Select(static _ => Unit.Default);
+}

--- a/src/Akavache.Core/Core/RequestCache.cs
+++ b/src/Akavache.Core/Core/RequestCache.cs
@@ -12,8 +12,9 @@ namespace Akavache.Core;
 /// </summary>
 internal static class RequestCache
 {
-    /// <summary>The set of currently in-flight requests, keyed by type-qualified cache key.</summary>
-    private static readonly ConcurrentDictionary<string, IObservable<object>> _inflightRequests = new();
+    /// <summary>The set of currently in-flight requests, keyed by type-qualified cache key.
+    /// Ordinal comparison — request keys are opaque identifiers, not user-facing text.</summary>
+    private static readonly ConcurrentDictionary<string, IObservable<object>> _inflightRequests = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Gets the number of currently in-flight requests (primarily for testing/debugging).
@@ -36,7 +37,7 @@ internal static class RequestCache
 
         return _inflightRequests.GetOrAdd(
             requestKey,
-            cacheKey => fetchFunc().Select(x => (object)x!)
+            cacheKey => fetchFunc().Select(static x => (object)x!)
                 .Do(
                     onNext: static _ => { },
                     onError: _ =>
@@ -50,7 +51,7 @@ internal static class RequestCache
                         RemoveRequestInternal(cacheKey);
                     })
                 .Replay(1)
-                .RefCount()).Select(x => (T)x);
+                .RefCount()).Select(static x => (T)x);
     }
 
     /// <summary>
@@ -85,8 +86,14 @@ internal static class RequestCache
         }
 
         var keySuffix = $":{key}";
-        List<string> keysToRemove = [];
-        keysToRemove.AddRange(_inflightRequests.Keys.Where(requestKey => requestKey.EndsWith(keySuffix, StringComparison.Ordinal)));
+        List<string> keysToRemove = new(_inflightRequests.Count);
+        foreach (var requestKey in _inflightRequests.Keys)
+        {
+            if (requestKey.EndsWith(keySuffix, StringComparison.Ordinal))
+            {
+                keysToRemove.Add(requestKey);
+            }
+        }
 
         foreach (var requestKey in keysToRemove)
         {

--- a/src/Akavache.Core/Helpers/BinaryHelpers.cs
+++ b/src/Akavache.Core/Helpers/BinaryHelpers.cs
@@ -17,6 +17,13 @@ namespace Akavache.Helpers;
 /// </summary>
 internal static class BinaryHelpers
 {
+#if NET5_0_OR_GREATER
+    /// <summary>Gets the ASCII whitespace byte set used by <see cref="StartsWithJsonOpener"/>'s
+    /// fast-path span trim — space, tab, LF, CR. Stored as a <c>u8</c> literal so the bytes
+    /// live in the assembly's data section, zero runtime allocation.</summary>
+    private static ReadOnlySpan<byte> AsciiWhitespace => " \t\n\r"u8;
+#endif
+
     /// <summary>
     /// Reads a little-endian 32-bit signed integer from the given byte array starting at
     /// <paramref name="offset"/>. The caller is responsible for ensuring the array contains
@@ -59,4 +66,40 @@ internal static class BinaryHelpers
                 | ((long)data[offset + 6] << 48)
                 | ((long)data[offset + 7] << 56));
 #endif
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="data"/>, after skipping leading ASCII
+    /// whitespace, starts with a JSON opener (<c>{</c> or <c>[</c>). Used by serializer format
+    /// probes that need to tell JSON and BSON payloads apart without allocating a decoded string.
+    /// </summary>
+    /// <param name="data">The raw payload bytes.</param>
+    /// <returns><see langword="true"/> if the first non-whitespace byte is <c>{</c> or <c>[</c>.</returns>
+    public static bool StartsWithJsonOpener(byte[] data)
+    {
+        if (data is null)
+        {
+            return false;
+        }
+
+#if NET5_0_OR_GREATER
+        // On modern runtimes, MemoryExtensions.TrimStart(ReadOnlySpan<byte>, ReadOnlySpan<byte>)
+        // can be vectorised by the JIT. Let the BCL do the whitespace skip in bulk.
+        var trimmed = data.AsSpan().TrimStart(AsciiWhitespace);
+        return !trimmed.IsEmpty && (trimmed[0] is (byte)'{' or (byte)'[');
+#else
+        // Scalar fallback for net462 / netstandard2.0 targets without span TrimStart(span).
+        for (var i = 0; i < data.Length; i++)
+        {
+            var b = data[i];
+            if (b is (byte)' ' or (byte)'\t' or (byte)'\n' or (byte)'\r')
+            {
+                continue;
+            }
+
+            return b is (byte)'{' or (byte)'[';
+        }
+
+        return false;
+#endif
+    }
 }

--- a/src/Akavache.Core/HttpService.cs
+++ b/src/Akavache.Core/HttpService.cs
@@ -72,7 +72,7 @@ public class HttpService : IHttpService
 
         var conn = ret.PublishLast();
         conn.Connect();
-        return conn.Select(x => x ?? []);
+        return conn.Select(static x => x ?? []);
     }
 
     /// <inheritdoc />
@@ -88,7 +88,7 @@ public class HttpService : IHttpService
         IObservable<byte[]> ret;
         if (!fetchAlways)
         {
-            ret = blobCache.Get(key).Catch(fetchAndCache).Select(x => x ?? []);
+            ret = blobCache.Get(key).Catch(fetchAndCache).Select(static x => x ?? []);
         }
         else
         {

--- a/src/Akavache.Core/InMemoryBlobCacheBase.cs
+++ b/src/Akavache.Core/InMemoryBlobCacheBase.cs
@@ -20,11 +20,20 @@ namespace Akavache;
 /// <param name="serializer">The serializer to use for object serialization/deserialization.</param>
 public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? serializer) : ISecureBlobCache
 {
-    /// <summary>The in-memory key to cache entry mapping.</summary>
-    private readonly Dictionary<string, CacheEntry> _cache = [];
+    /// <summary>The in-memory key to cache entry mapping. Uses ordinal comparison — cache keys
+    /// are opaque identifiers, not user-facing text, so culture-sensitive collation would be
+    /// both wrong and slower.</summary>
+    private readonly Dictionary<string, CacheEntry> _cache = new(StringComparer.Ordinal);
 
-    /// <summary>Per-type index of keys for fast type-scoped lookups.</summary>
+    /// <summary>Per-type index of keys for fast type-scoped lookups. Inner sets also use
+    /// ordinal comparison for the same reason as <see cref="_cache"/>.</summary>
     private readonly Dictionary<Type, HashSet<string>> _typeIndex = [];
+
+    /// <summary>Reverse map from cache key to the <see cref="Type"/> bucket it currently lives
+    /// in, if any. Populated by the typed <c>Insert</c> overloads and cleared alongside
+    /// <see cref="_cache"/>. Lets removal paths delete a key from <see cref="_typeIndex"/> in
+    /// O(1) instead of scanning every registered type's <see cref="HashSet{T}"/>.</summary>
+    private readonly Dictionary<string, Type> _keyToType = new(StringComparer.Ordinal);
 #if NET9_0_OR_GREATER
     /// <summary>Synchronization primitive guarding mutations of the cache and type index.</summary>
     private readonly Lock _lock = new();
@@ -65,28 +74,32 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
     public IObservable<Unit> Insert(IEnumerable<KeyValuePair<string, byte[]>> keyValuePairs, DateTimeOffset? absoluteExpiration = null)
     {
         ArgumentExceptionHelper.ThrowIfNull(keyValuePairs);
-        return _disposed
-            ? IBlobCache.ExceptionHelpers.ObservableThrowObjectDisposedException<Unit>(GetType().Name)
-            : Observable.Start(
-                () =>
-                {
-                    lock (_lock)
-                    {
-                        foreach (var pair in keyValuePairs)
-                        {
-                            _cache[pair.Key] = new()
-                            {
-                                Id = pair.Key,
-                                Value = pair.Value,
-                                CreatedAt = Scheduler.Now,
-                                ExpiresAt = absoluteExpiration,
-                            };
-                        }
-                    }
+        if (_disposed)
+        {
+            return IBlobCache.ExceptionHelpers.ObservableThrowObjectDisposedException<Unit>(GetType().Name);
+        }
 
-                    return Unit.Default;
-                },
-                Scheduler);
+        // Empty-input guard — skip the Observable.Start scheduling and lock acquisition entirely.
+        if (keyValuePairs is ICollection<KeyValuePair<string, byte[]>> { Count: 0 })
+        {
+            return Core.CachedObservables.UnitDefault;
+        }
+
+        return Observable.Start(
+            () =>
+            {
+                lock (_lock)
+                {
+                    var now = Scheduler.Now;
+                    foreach (var pair in keyValuePairs)
+                    {
+                        _cache[pair.Key] = new CacheEntry(pair.Key, typeName: null, pair.Value, now, absoluteExpiration);
+                    }
+                }
+
+                return Unit.Default;
+            },
+            Scheduler);
     }
 
     /// <inheritdoc />
@@ -98,13 +111,7 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                 {
                     lock (_lock)
                     {
-                        _cache[key] = new()
-                        {
-                            Id = key,
-                            Value = data,
-                            CreatedAt = Scheduler.Now,
-                            ExpiresAt = absoluteExpiration,
-                        };
+                        _cache[key] = new CacheEntry(key, typeName: null, data, Scheduler.Now, absoluteExpiration);
                     }
 
                     return Unit.Default;
@@ -112,37 +119,53 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                 Scheduler);
 
     /// <inheritdoc />
-    public IObservable<Unit> Insert(IEnumerable<KeyValuePair<string, byte[]>> keyValuePairs, Type type, DateTimeOffset? absoluteExpiration = null) =>
-        _disposed
-            ? IBlobCache.ExceptionHelpers.ObservableThrowObjectDisposedException<Unit>(GetType().Name)
-            : Observable.Start(
-                () =>
-                {
-                    lock (_lock)
-                    {
-                        if (!_typeIndex.TryGetValue(type, out var value))
-                        {
-                            value = [];
-                            _typeIndex[type] = value;
-                        }
+    public IObservable<Unit> Insert(IEnumerable<KeyValuePair<string, byte[]>> keyValuePairs, Type type, DateTimeOffset? absoluteExpiration = null)
+    {
+        if (_disposed)
+        {
+            return IBlobCache.ExceptionHelpers.ObservableThrowObjectDisposedException<Unit>(GetType().Name);
+        }
 
-                        foreach (var pair in keyValuePairs)
-                        {
-                            _cache[pair.Key] = new()
-                            {
-                                Id = pair.Key,
-                                TypeName = type.FullName,
-                                Value = pair.Value,
-                                CreatedAt = Scheduler.Now,
-                                ExpiresAt = absoluteExpiration,
-                            };
-                            value.Add(pair.Key);
-                        }
+        // Empty-input guard — skip the Observable.Start scheduling and lock acquisition entirely.
+        if (keyValuePairs is ICollection<KeyValuePair<string, byte[]>> { Count: 0 })
+        {
+            return Core.CachedObservables.UnitDefault;
+        }
+
+        return Observable.Start(
+            () =>
+            {
+                lock (_lock)
+                {
+                    if (!_typeIndex.TryGetValue(type, out var value))
+                    {
+                        value = new HashSet<string>(StringComparer.Ordinal);
+                        _typeIndex[type] = value;
                     }
 
-                    return Unit.Default;
-                },
-                Scheduler);
+                    var typeFullName = type.FullName;
+                    var now = Scheduler.Now;
+                    foreach (var pair in keyValuePairs)
+                    {
+                        // If this key was previously associated with a different type, evict it
+                        // from that bucket first so the reverse-index invariant (one type per key)
+                        // holds and subsequent O(1) removal works.
+                        if (_keyToType.TryGetValue(pair.Key, out var previousType) && previousType != type
+                            && _typeIndex.TryGetValue(previousType, out var previousSet))
+                        {
+                            previousSet.Remove(pair.Key);
+                        }
+
+                        _cache[pair.Key] = new CacheEntry(pair.Key, typeFullName, pair.Value, now, absoluteExpiration);
+                        value.Add(pair.Key);
+                        _keyToType[pair.Key] = type;
+                    }
+                }
+
+                return Unit.Default;
+            },
+            Scheduler);
+    }
 
     /// <inheritdoc />
     public IObservable<Unit> Insert(string key, byte[] data, Type type, DateTimeOffset? absoluteExpiration = null) =>
@@ -155,19 +178,20 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                     {
                         if (!_typeIndex.TryGetValue(type, out var value))
                         {
-                            value = [];
+                            value = new HashSet<string>(StringComparer.Ordinal);
                             _typeIndex[type] = value;
                         }
 
-                        _cache[key] = new()
+                        // Evict from a previous type bucket so the one-type-per-key invariant holds.
+                        if (_keyToType.TryGetValue(key, out var previousType) && previousType != type
+                            && _typeIndex.TryGetValue(previousType, out var previousSet))
                         {
-                            Id = key,
-                            TypeName = type.FullName,
-                            Value = data,
-                            CreatedAt = Scheduler.Now,
-                            ExpiresAt = absoluteExpiration,
-                        };
+                            previousSet.Remove(key);
+                        }
+
+                        _cache[key] = new CacheEntry(key, type.FullName, data, Scheduler.Now, absoluteExpiration);
                         value.Add(key);
+                        _keyToType[key] = type;
                     }
 
                     return Unit.Default;
@@ -238,8 +262,8 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                         }
 
                         var now = Scheduler.Now;
-                        List<KeyValuePair<string, byte[]>> result = [];
-                        List<string> expiredKeys = [];
+                        List<KeyValuePair<string, byte[]>> result = new(keys.Count);
+                        List<string> expiredKeys = new(keys.Count);
 
                         foreach (var key in keys)
                         {
@@ -266,7 +290,7 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                         return result;
                     }
                 },
-                Scheduler).SelectMany(x => x);
+                Scheduler).SelectMany(static x => x);
 
     /// <inheritdoc />
     public IObservable<string> GetAllKeys() =>
@@ -278,8 +302,8 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                     lock (_lock)
                     {
                         var now = Scheduler.Now;
-                        List<string> expiredKeys = [];
-                        List<string> validKeys = [];
+                        List<string> expiredKeys = new(_cache.Count);
+                        List<string> validKeys = new(_cache.Count);
 
                         foreach (var kvp in _cache)
                         {
@@ -302,7 +326,7 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                         return validKeys;
                     }
                 },
-                Scheduler).SelectMany(x => x);
+                Scheduler).SelectMany(static x => x);
 
     /// <inheritdoc />
     public IObservable<string> GetAllKeys(Type type) =>
@@ -319,8 +343,8 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                         }
 
                         var now = Scheduler.Now;
-                        List<string> expiredKeys = [];
-                        List<string> validKeys = [];
+                        List<string> expiredKeys = new(keys.Count);
+                        List<string> validKeys = new(keys.Count);
 
                         foreach (var key in keys)
                         {
@@ -347,7 +371,7 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                         return validKeys;
                     }
                 },
-                Scheduler).SelectMany(x => x);
+                Scheduler).SelectMany(static x => x);
 
     /// <inheritdoc />
     public IObservable<(string Key, DateTimeOffset? Time)> GetCreatedAt(IEnumerable<string> keys) =>
@@ -386,10 +410,10 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
     public IObservable<DateTimeOffset?> GetCreatedAt(string key, Type type) => GetCreatedAt(key);
 
     /// <inheritdoc />
-    public IObservable<Unit> Flush() => Observable.Return(Unit.Default);
+    public IObservable<Unit> Flush() => Core.CachedObservables.UnitDefault;
 
     /// <inheritdoc />
-    public IObservable<Unit> Flush(Type type) => Observable.Return(Unit.Default);
+    public IObservable<Unit> Flush(Type type) => Core.CachedObservables.UnitDefault;
 
     /// <inheritdoc />
     public IObservable<Unit> Invalidate(string key) =>
@@ -401,13 +425,7 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                     lock (_lock)
                     {
                         _cache.Remove(key);
-
-                        // Remove from type indexes
-                        // Iterate directly over the dictionary to avoid concurrent HashSet access issues
-                        foreach (var kvp in _typeIndex)
-                        {
-                            kvp.Value.Remove(key);
-                        }
+                        RemoveKeyFromTypeIndexFast(_typeIndex, _keyToType, key);
                     }
 
                     // Clear any pending requests for this key to ensure GetOrFetchObject
@@ -422,39 +440,44 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
     public IObservable<Unit> Invalidate(string key, Type type) => Invalidate(key);
 
     /// <inheritdoc />
-    public IObservable<Unit> Invalidate(IEnumerable<string> keys) =>
-        _disposed
-            ? IBlobCache.ExceptionHelpers.ObservableThrowObjectDisposedException<Unit>(GetType().Name)
-            : Observable.Start(
-                () =>
+    public IObservable<Unit> Invalidate(IEnumerable<string> keys)
+    {
+        if (_disposed)
+        {
+            return IBlobCache.ExceptionHelpers.ObservableThrowObjectDisposedException<Unit>(GetType().Name);
+        }
+
+        // Empty-input guard — skip the Observable.Start scheduling and lock acquisition entirely.
+        if (keys is ICollection<string> { Count: 0 })
+        {
+            return Core.CachedObservables.UnitDefault;
+        }
+
+        return Observable.Start(
+            () =>
+            {
+                var keysToInvalidate = keys.ToList(); // Materialize the enumerable
+
+                lock (_lock)
                 {
-                    var keysToInvalidate = keys.ToList(); // Materialize the enumerable
-
-                    lock (_lock)
-                    {
-                        foreach (var key in keysToInvalidate)
-                        {
-                            _cache.Remove(key);
-
-                            // Remove from type indexes
-                            // Iterate directly over the dictionary to avoid concurrent HashSet access issues
-                            foreach (var kvp in _typeIndex)
-                            {
-                                kvp.Value.Remove(key);
-                            }
-                        }
-                    }
-
-                    // Clear any pending requests for these keys to ensure GetOrFetchObject
-                    // will actually fetch fresh data instead of returning cached request results
                     foreach (var key in keysToInvalidate)
                     {
-                        RequestCache.RemoveRequestsForKey(key);
+                        _cache.Remove(key);
+                        RemoveKeyFromTypeIndexFast(_typeIndex, _keyToType, key);
                     }
+                }
 
-                    return Unit.Default;
-                },
-                Scheduler);
+                // Clear any pending requests for these keys to ensure GetOrFetchObject
+                // will actually fetch fresh data instead of returning cached request results
+                foreach (var key in keysToInvalidate)
+                {
+                    RequestCache.RemoveRequestsForKey(key);
+                }
+
+                return Unit.Default;
+            },
+            Scheduler);
+    }
 
     /// <inheritdoc />
     public IObservable<Unit> InvalidateAll(Type type) =>
@@ -469,11 +492,13 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                     {
                         if (_typeIndex.TryGetValue(type, out var keys))
                         {
-                            keysToInvalidate.AddRange(keys); // Capture keys before clearing
+                            // Capture keys before clearing. Spread pre-sizes from the ICollection source.
+                            keysToInvalidate = [.. keys];
 
                             foreach (var key in keys)
                             {
                                 _cache.Remove(key);
+                                _keyToType.Remove(key);
                             }
 
                             keys.Clear();
@@ -505,6 +530,7 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                     {
                         _cache.Clear();
                         _typeIndex.Clear();
+                        _keyToType.Clear();
                     }
 
                     // Clear all pending requests to ensure GetOrFetchObject
@@ -620,7 +646,7 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
                 {
                     lock (_lock)
                     {
-                        VacuumExpiredEntries(_cache, _typeIndex, Scheduler.Now);
+                        VacuumExpiredEntriesFast(_cache, _typeIndex, _keyToType, Scheduler.Now);
                     }
 
                     return Unit.Default;
@@ -636,7 +662,7 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
 
     /// <inheritdoc />
     [SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "Dispose already calls SuppressFinalize")]
-    public async ValueTask DisposeAsync() => await Task.Run(Dispose);
+    public ValueTask DisposeAsync() => new(Task.Run(Dispose));
 
     /// <summary>
     /// Insert an object into the cache using the configured serializer.
@@ -679,10 +705,10 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
             ? IBlobCache.ExceptionHelpers.ObservableThrowObjectDisposedException<IEnumerable<T>>(GetType().Name)
             : GetAll(typeof(T))
                 .Select(kvp => Serializer.Deserialize<T>(kvp.Value))
-                .Where(obj => obj is not null)
-                .Select(obj => obj!)
+                .Where(static obj => obj is not null)
+                .Select(static obj => obj!)
                 .ToList()
-                .Select(list => (IEnumerable<T>)list);
+                .Select(static list => (IEnumerable<T>)list);
 
     /// <summary>
     /// Returns the time that the object with the key was added to the cache, or returns
@@ -731,6 +757,55 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
     }
 
     /// <summary>
+    /// O(1) vacuum that uses <paramref name="keyToType"/> for type-index removal instead of
+    /// scanning every registered type. Keeps <see cref="VacuumExpiredEntries"/> around for
+    /// unit tests that exercise the all-scan logic directly.
+    /// </summary>
+    /// <param name="cache">The key-to-entry dictionary to vacuum.</param>
+    /// <param name="typeIndex">The per-type key index to prune.</param>
+    /// <param name="keyToType">Reverse key-to-type map maintained alongside <paramref name="typeIndex"/>.</param>
+    /// <param name="now">The cutoff time used to determine expiration.</param>
+    internal static void VacuumExpiredEntriesFast(
+        Dictionary<string, CacheEntry> cache,
+        Dictionary<Type, HashSet<string>> typeIndex,
+        Dictionary<string, Type> keyToType,
+        DateTimeOffset now)
+    {
+        foreach (var expiredKey in CollectExpiredKeys(cache, now))
+        {
+            cache.Remove(expiredKey);
+            RemoveKeyFromTypeIndexFast(typeIndex, keyToType, expiredKey);
+        }
+    }
+
+    /// <summary>
+    /// Removes <paramref name="key"/> from whichever type's set it currently lives in, as
+    /// recorded by <paramref name="keyToType"/>. O(1) replacement for the historical all-scan.
+    /// Safe to call when the key isn't in any type set (e.g. it was inserted via an untyped
+    /// <c>Insert</c>).
+    /// </summary>
+    /// <param name="typeIndex">The per-type key index being pruned.</param>
+    /// <param name="keyToType">Reverse key-to-type map.</param>
+    /// <param name="key">The cache key being removed.</param>
+    internal static void RemoveKeyFromTypeIndexFast(
+        Dictionary<Type, HashSet<string>> typeIndex,
+        Dictionary<string, Type> keyToType,
+        string key)
+    {
+        if (!keyToType.TryGetValue(key, out var type))
+        {
+            return;
+        }
+
+        if (typeIndex.TryGetValue(type, out var set))
+        {
+            set.Remove(key);
+        }
+
+        keyToType.Remove(key);
+    }
+
+    /// <summary>
     /// Returns the list of keys in <paramref name="cache"/> whose <c>ExpiresAt</c> is at or
     /// before <paramref name="now"/>. Static so the iteration is directly testable.
     /// </summary>
@@ -741,7 +816,7 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
         Dictionary<string, CacheEntry> cache,
         DateTimeOffset now)
     {
-        List<string> expiredKeys = [];
+        List<string> expiredKeys = new(cache.Count);
         foreach (var kvp in cache)
         {
             if (kvp.Value.ExpiresAt <= now)
@@ -787,6 +862,7 @@ public abstract class InMemoryBlobCacheBase(IScheduler scheduler, ISerializer? s
             {
                 _cache.Clear();
                 _typeIndex.Clear();
+                _keyToType.Clear();
             }
         }
 

--- a/src/Akavache.Core/SerializerExtensions.cs
+++ b/src/Akavache.Core/SerializerExtensions.cs
@@ -50,7 +50,7 @@ public static class SerializerExtensions
         return blobCache
             .Get(keys, typeof(T))
             .Select(x => (x.Key, Data: blobCache.Serializer.Deserialize<T>(x.Value)))
-            .Where(x => x.Data is not null).Select(x => new KeyValuePair<string, T>(x.Key, x.Data!));
+            .Where(static x => x.Data is not null).Select(static x => new KeyValuePair<string, T>(x.Key, x.Data!));
     }
 
     /// <summary>
@@ -149,8 +149,8 @@ public static class SerializerExtensions
         return blobCache
             .GetAll(typeof(T))
             .Select(x => blobCache.Serializer.Deserialize<T>(x.Value))
-            .Where(x => x is not null)
-            .Select(x => x!);
+            .Where(static x => x is not null)
+            .Select(static x => x!);
     }
 
     /// <summary>
@@ -385,14 +385,14 @@ public static class SerializerExtensions
     {
         var fetch = Observable.Defer(() => blobCache.GetObjectCreatedAt<T>(key))
             .Select(x => ShouldRefetchCachedValue(fetchPredicate, x))
-            .Where(x => x)
+            .Where(static x => x)
             .SelectMany(_ =>
             {
                 var fetchObs = fetchFunc().Catch<T, Exception>(ex =>
                 {
                     var shouldInvalidate = shouldInvalidateOnError ?
                         blobCache.InvalidateObject<T>(key) :
-                        Observable.Return(Unit.Default);
+                        Core.CachedObservables.UnitDefault;
                     return shouldInvalidate.SelectMany(_ => Observable.Throw<T>(ex));
                 });
 
@@ -407,10 +407,10 @@ public static class SerializerExtensions
                             : blobCache.InsertObject(key, x, absoluteExpiration).Select(_ => x));
             });
 
-        var result = blobCache.GetObject<T>(key).Select(x => (x, true))
+        var result = blobCache.GetObject<T>(key).Select(static x => (x, true))
             .Catch(Observable.Return((default(T), false)));
 
-        return result.SelectMany(x => x.Item2 ? Observable.Return(x.Item1) : Observable.Empty<T>())
+        return result.SelectMany(static x => x.Item2 ? Observable.Return(x.Item1) : Observable.Empty<T>())
             .Concat(fetch)
             .Multicast(new ReplaySubject<T?>())
             .RefCount();
@@ -480,7 +480,7 @@ public static class SerializerExtensions
 
         if (keyValuePairs.Count == 0)
         {
-            return Observable.Return(Unit.Default);
+            return Core.CachedObservables.UnitDefault;
         }
 
         // For mixed object types, we need to serialize each one individually and use its specific type
@@ -492,7 +492,7 @@ public static class SerializerExtensions
         return insertOperations.Merge()
             .TakeLast(insertOperations.Count)
             .LastOrDefaultAsync()
-            .Select(_ => Unit.Default);
+            .SelectUnit();
     }
 
     /// <summary>

--- a/src/Akavache.Core/UniversalSerializer.cs
+++ b/src/Akavache.Core/UniversalSerializer.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Akavache.Helpers;
 
@@ -15,6 +16,21 @@ public static class UniversalSerializer
 {
     /// <summary>The list of factories registered for fallback serializer creation.</summary>
     private static readonly List<Func<ISerializer>> _registeredSerializerFactories = [];
+
+    /// <summary>
+    /// Per-serializer-type cache for the "does the type name contain 'Bson'" check. The check
+    /// runs on every fallback deserialize attempt and previously materialized the type name
+    /// plus ran a substring probe on every call; caching by <see cref="Type"/> keeps the hot
+    /// path allocation-free.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Type, bool> _isBsonSerializerByType = new();
+
+    /// <summary>
+    /// Per-serializer-type cache for the "is this the plain (non-BSON) Newtonsoft serializer"
+    /// check used by <see cref="PreprocessDateTimeForSerialization"/> to work around
+    /// Newtonsoft.Json's DateTime.MinValue/MaxValue quirks.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Type, bool> _isPlainNewtonsoftSerializerByType = new();
 
     /// <summary>Cached list of alternative serializer instances, invalidated on registration.</summary>
     private static List<ISerializer>? _alternativeSerializers;
@@ -144,8 +160,9 @@ public static class UniversalSerializer
 
         try
         {
-            // Get all available keys from the cache
-            var allKeys = await cache.GetAllKeys().ToList().FirstAsync();
+            // Get all available keys from the cache. Awaiting the Rx observable already takes
+            // the last (and only) emission, so FirstAsync() on top of ToList() was redundant.
+            var allKeys = await cache.GetAllKeys().ToList();
 
             if (allKeys.Count == 0)
             {
@@ -279,16 +296,19 @@ public static class UniversalSerializer
     /// <returns>The candidate subset of <paramref name="allKeys"/>.</returns>
     internal static List<string> FindKeyCandidates<T>(IEnumerable<string> allKeys, string requestedKey)
     {
+        // Cached per-T reflection strings avoid re-walking typeof(T).FullName / .Name /
+        // Assembly.GetName().Name on every lookup. Each string interpolation below also
+        // only touches the (cached) T metadata plus the per-call requestedKey.
         HashSet<string> possibleKeys =
         [
             requestedKey,
-            $"{typeof(T).FullName}___{requestedKey}",
-            $"{typeof(T).Name}___{requestedKey}",
-            $"{typeof(T).Assembly.GetName().Name}.{typeof(T).Name}___{requestedKey}"
+            $"{KeyMetadata<T>.FullName}___{requestedKey}",
+            $"{KeyMetadata<T>.Name}___{requestedKey}",
+            $"{KeyMetadata<T>.AssemblyQualifiedShortName}___{requestedKey}"
         ];
 
         var prefixSuffix = $"___{requestedKey}";
-        List<string> candidates = [];
+        List<string> candidates = new(8);
         foreach (var key in allKeys)
         {
             if (possibleKeys.Contains(key) || key.EndsWith(prefixSuffix, StringComparison.Ordinal))
@@ -582,7 +602,7 @@ public static class UniversalSerializer
                 var serializer = factory();
 
                 // Only use serializers that look like BSON serializers
-                if (!serializer.GetType().Name.Contains("Bson", StringComparison.OrdinalIgnoreCase))
+                if (!IsBsonSerializer(serializer))
                 {
                     continue;
                 }
@@ -647,7 +667,7 @@ public static class UniversalSerializer
                 var serializer = factory();
 
                 // Skip BSON serializers - we want JSON ones
-                if (serializer.GetType().Name.Contains("Bson", StringComparison.OrdinalIgnoreCase))
+                if (IsBsonSerializer(serializer))
                 {
                     continue;
                 }
@@ -701,27 +721,18 @@ public static class UniversalSerializer
     /// <returns>The preprocessed DateTime value.</returns>
     internal static DateTime PreprocessDateTimeForSerialization(DateTime dateTime, ISerializer serializer, DateTimeKind? forcedDateTimeKind)
     {
-        var serializerTypeName = serializer.GetType().Name;
-
-        // Handle special cases for problematic DateTime values
-        if (dateTime == DateTime.MinValue)
+        // Handle special cases for problematic DateTime values. Cached type probe replaces
+        // two Contains() calls against GetType().Name per invocation.
+        if (dateTime == DateTime.MinValue && IsPlainNewtonsoftSerializer(serializer))
         {
-            // Some serializers have issues with DateTime.MinValue
-            if (serializerTypeName.Contains("Newtonsoft") && !serializerTypeName.Contains("Bson"))
-            {
-                // Use a safer minimum date for regular Newtonsoft serializer
-                return new(1900, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            }
+            // Use a safer minimum date for regular Newtonsoft serializer
+            return new(1900, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         }
 
-        if (dateTime == DateTime.MaxValue)
+        if (dateTime == DateTime.MaxValue && IsPlainNewtonsoftSerializer(serializer))
         {
-            // Some serializers have issues with DateTime.MaxValue
-            if (serializerTypeName.Contains("Newtonsoft") && !serializerTypeName.Contains("Bson"))
-            {
-                // Use a safer maximum date for regular Newtonsoft serializer
-                return new(2100, 12, 31, 23, 59, 59, DateTimeKind.Utc);
-            }
+            // Use a safer maximum date for regular Newtonsoft serializer
+            return new(2100, 12, 31, 23, 59, 59, DateTimeKind.Utc);
         }
 
         // Apply forced DateTime kind via the shared converter helper.
@@ -737,5 +748,34 @@ public static class UniversalSerializer
     {
         _registeredSerializerFactories.Clear();
         _alternativeSerializers = null;
+        _isBsonSerializerByType.Clear();
+        _isPlainNewtonsoftSerializerByType.Clear();
     }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="serializer"/>'s runtime type name contains
+    /// "Bson". Result is cached per <see cref="Type"/>.
+    /// </summary>
+    /// <param name="serializer">The serializer instance to probe.</param>
+    /// <returns><see langword="true"/> if the serializer is a BSON variant.</returns>
+    internal static bool IsBsonSerializer(ISerializer serializer) =>
+        _isBsonSerializerByType.GetOrAdd(
+            serializer.GetType(),
+            static t => t.Name.Contains("Bson", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="serializer"/> is the plain (non-BSON)
+    /// Newtonsoft.Json serializer. Result is cached per <see cref="Type"/>.
+    /// </summary>
+    /// <param name="serializer">The serializer instance to probe.</param>
+    /// <returns><see langword="true"/> if the serializer is Newtonsoft.Json (not the BSON variant).</returns>
+    internal static bool IsPlainNewtonsoftSerializer(ISerializer serializer) =>
+        _isPlainNewtonsoftSerializerByType.GetOrAdd(
+            serializer.GetType(),
+            static t =>
+            {
+                var name = t.Name;
+                return name.Contains("Newtonsoft", StringComparison.OrdinalIgnoreCase)
+                    && !name.Contains("Bson", StringComparison.OrdinalIgnoreCase);
+            });
 }

--- a/src/Akavache.Drawing/BitmapImageExtensions.cs
+++ b/src/Akavache.Drawing/BitmapImageExtensions.cs
@@ -149,12 +149,15 @@ public static class BitmapImageExtensions
 
         return Observable.FromAsync(async () =>
         {
+            // Pre-size the buffer to a typical small-PNG worst case so a sequence of regrowths
+            // (starting at 256 and doubling) is avoided for anything under ~16 KB.
+            const int InitialCapacity = 16 * 1024;
 #if NETFRAMEWORK
-            using var stream = new MemoryStream();
+            using var stream = new MemoryStream(InitialCapacity);
 #else
-            await using MemoryStream stream = new();
+            await using MemoryStream stream = new(InitialCapacity);
 #endif
-            await image.Save(CompressedBitmapFormat.Png, 1.0f, stream);
+            await image.Save(CompressedBitmapFormat.Png, 1.0f, stream).ConfigureAwait(false);
             return stream.ToArray();
         });
     }
@@ -199,11 +202,11 @@ public static class BitmapImageExtensions
         Observable.FromAsync(async () =>
         {
 #if NETFRAMEWORK
-            using var ms = new MemoryStream(compressedImage);
+            using var ms = new MemoryStream(compressedImage, writable: false);
 #else
-            await using MemoryStream ms = new(compressedImage);
+            await using MemoryStream ms = new(compressedImage, writable: false);
 #endif
-            var bitmap = await BitmapLoader.Current.Load(ms, desiredWidth, desiredHeight);
+            var bitmap = await BitmapLoader.Current.Load(ms, desiredWidth, desiredHeight).ConfigureAwait(false);
             return bitmap ?? throw new IOException("Failed to load the bitmap!");
         });
 }

--- a/src/Akavache.Drawing/ImageCacheExtensions.cs
+++ b/src/Akavache.Drawing/ImageCacheExtensions.cs
@@ -44,8 +44,8 @@ public static class ImageCacheExtensions
 
         return urls.ToObservable()
             .SelectMany(url => blobCache.DownloadUrl(url, absoluteExpiration: absoluteExpiration)
-                .Catch<byte[], Exception>(_ => Observable.Empty<byte[]>()))
-            .Select(_ => Unit.Default)
+                .Catch<byte[], Exception>(static _ => Observable.Empty<byte[]>()))
+            .Select(static _ => Unit.Default)
             .DefaultIfEmpty(Unit.Default)
             .TakeLast(1);
     }
@@ -120,18 +120,17 @@ public static class ImageCacheExtensions
 
         return blobCache.Get(key)
             .SelectMany(static bytes => BitmapImageExtensions.ThrowOnNullOrBadImageBuffer(bytes))
-            .SelectMany(bytes =>
+            .SelectMany(static bytes =>
                 Observable.FromAsync(async () =>
                 {
 #if NETFRAMEWORK
-                    using var ms = new MemoryStream(bytes);
+                    using var ms = new MemoryStream(bytes, writable: false);
 #else
-                    await using var ms = new MemoryStream(bytes);
+                    await using var ms = new MemoryStream(bytes, writable: false);
 #endif
-                    var bitmap = await BitmapLoader.Current.Load(ms, null, null);
+                    var bitmap = await BitmapLoader.Current.Load(ms, null, null).ConfigureAwait(false);
                     return bitmap != null ? new Size(bitmap.Width, bitmap.Height) : throw new InvalidOperationException("Failed to load image for size detection");
-                }))
-            .SelectMany(static size => Observable.Return(size));
+                }));
     }
 
     /// <summary>
@@ -167,11 +166,11 @@ public static class ImageCacheExtensions
         Observable.FromAsync(async () =>
         {
 #if NETFRAMEWORK
-            using var ms = new MemoryStream(compressedImage);
+            using var ms = new MemoryStream(compressedImage, writable: false);
 #else
-            await using MemoryStream ms = new(compressedImage);
+            await using MemoryStream ms = new(compressedImage, writable: false);
 #endif
-            var bitmap = await BitmapLoader.Current.Load(ms, desiredWidth, desiredHeight);
+            var bitmap = await BitmapLoader.Current.Load(ms, desiredWidth, desiredHeight).ConfigureAwait(false);
             return bitmap ?? throw new IOException("Failed to load the bitmap!");
         });
 }

--- a/src/Akavache.NewtonsoftJson/NewtonsoftSerializer.cs
+++ b/src/Akavache.NewtonsoftJson/NewtonsoftSerializer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+using Akavache.Helpers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Bson;
 
@@ -71,9 +72,9 @@ public class NewtonsoftSerializer : ISerializer
             return false;
         }
 
-        // Additional check: try to identify JSON by looking for common JSON patterns in the data.
-        var dataString = Encoding.UTF8.GetString(data);
-        return !(dataString.TrimStart().StartsWith("{") || dataString.TrimStart().StartsWith("["));
+        // Additional check: if the payload starts with a JSON opener (after whitespace),
+        // it's probably JSON, not BSON. Byte-level probe — zero allocations.
+        return !BinaryHelpers.StartsWithJsonOpener(data);
     }
 
     /// <inheritdoc/>
@@ -102,7 +103,7 @@ public class NewtonsoftSerializer : ISerializer
         // Try JSON format
         try
         {
-            using MemoryStream stream = new(bytes);
+            using MemoryStream stream = new(bytes, writable: false);
             using StreamReader textReader = new(stream);
             var serializer = JsonSerializer.Create(GetEffectiveSettings());
             return (T?)serializer.Deserialize(textReader, typeof(T));
@@ -172,7 +173,7 @@ public class NewtonsoftSerializer : ISerializer
         try
         {
             var serializer = GetSerializer();
-            using MemoryStream ms = new();
+            using MemoryStream ms = new(capacity: 256);
             using BsonDataWriter writer = new(ms);
 
             serializer.Serialize(writer, new ObjectWrapper<T>(item));
@@ -200,7 +201,7 @@ public class NewtonsoftSerializer : ISerializer
         try
         {
             var serializer = GetSerializer();
-            using BsonDataReader reader = new(new MemoryStream(bytes));
+            using BsonDataReader reader = new(new MemoryStream(bytes, writable: false));
 
             var forcedDateTimeKind = ForcedDateTimeKind;
             if (forcedDateTimeKind.HasValue)
@@ -217,7 +218,7 @@ public class NewtonsoftSerializer : ISerializer
             {
                 // Reset stream and try direct deserialization
                 reader.Close();
-                using BsonDataReader reader2 = new(new MemoryStream(bytes));
+                using BsonDataReader reader2 = new(new MemoryStream(bytes, writable: false));
                 if (forcedDateTimeKind.HasValue)
                 {
                     reader2.DateTimeKindHandling = forcedDateTimeKind.Value;
@@ -258,18 +259,16 @@ public class NewtonsoftSerializer : ISerializer
             }
         }
 
-        // Try JSON format
+        // Try JSON format. Byte-level probe first — lets us skip the UTF-8 decode when the
+        // payload clearly isn't JSON (the common fallback-from-BSON path).
+        if (!BinaryHelpers.StartsWithJsonOpener(bytes))
+        {
+            return default;
+        }
+
         try
         {
             var jsonString = Encoding.UTF8.GetString(bytes);
-
-            // Skip if it doesn't look like JSON
-            if (string.IsNullOrWhiteSpace(jsonString) ||
-                (!jsonString.TrimStart().StartsWith("{") && !jsonString.TrimStart().StartsWith("[")))
-            {
-                return default;
-            }
-
             var settings = GetEffectiveSettings();
 
             // Try ObjectWrapper format first (from BSON serializers).

--- a/src/Akavache.Sqlite3/SqliteAkavacheConnection.cs
+++ b/src/Akavache.Sqlite3/SqliteAkavacheConnection.cs
@@ -154,19 +154,21 @@ internal sealed class SqliteAkavacheConnection : IAkavacheConnection
         new(CloseAsync());
 
     /// <summary>
-    /// Executes a single legacy SELECT statement, swallowing "table/column not found" style
-    /// exceptions so the caller can fall through to the next query form.
+    /// Executes a single legacy SELECT statement, swallowing sqlite-net schema errors (missing
+    /// table / missing column, typical when the DB is already on the v11 schema) so the caller
+    /// can fall through to the next query form. Non-SQLite failures (e.g. disposed connection,
+    /// cancellation) propagate unchanged so real bugs aren't masked.
     /// </summary>
     /// <param name="sql">The legacy SQL statement.</param>
     /// <param name="args">Bound parameters.</param>
-    /// <returns>The matching blob, or <see langword="null"/> if the query failed or returned no row.</returns>
+    /// <returns>The matching blob, or <see langword="null"/> if the legacy schema isn't present.</returns>
     private async Task<byte[]?> TryExecuteLegacyAsync(string sql, object[] args)
     {
         try
         {
             return await _connection.ExecuteScalarAsync<byte[]?>(sql, args).ConfigureAwait(false);
         }
-        catch
+        catch (SQLiteException)
         {
             // Table/columns may not exist in newer DBs — caller falls through to the next form.
             return null;

--- a/src/Akavache.Sqlite3/SqliteAkavacheConnection.cs
+++ b/src/Akavache.Sqlite3/SqliteAkavacheConnection.cs
@@ -116,47 +116,33 @@ internal sealed class SqliteAkavacheConnection : IAkavacheConnection
     {
         // V10 schema columns: Key (varchar), TypeName (varchar), Value (BLOB), Expiration (bigint), CreatedAt (bigint).
         // Expiration is ticks (bigint). NULL or 0 means unexpired; otherwise require Expiration > nowTicks.
-        // Box nowTicks once and reuse the same boxed reference across every parameter array
-        // — sqlite-net's parameter API takes object[], so a long would otherwise box per array.
+        // Box nowTicks once and reuse the same boxed reference across every parameter array —
+        // sqlite-net's parameter API takes object[], so a long would otherwise box per array.
         object boxedNowTicks = now.UtcTicks;
-        const string expiryPredicate = "(Expiration IS NULL OR Expiration = 0 OR Expiration > ?)";
+        const string TypedSql = "SELECT Value FROM CacheElement WHERE Key = ? AND (Expiration IS NULL OR Expiration = 0 OR Expiration > ?) AND TypeName = ?";
+        const string UntypedSql = "SELECT Value FROM CacheElement WHERE Key = ? AND (Expiration IS NULL OR Expiration = 0 OR Expiration > ?)";
 
-        var sqlStatements = new List<(string Sql, object[] Args)>(3);
+        // Try each legacy form inline instead of materialising a List<(string, object[])> —
+        // keeps the cold-path allocation footprint to the per-query parameter arrays only.
         if (type is not null)
         {
             if (!string.IsNullOrWhiteSpace(type.AssemblyQualifiedName))
             {
-                sqlStatements.Add((
-                    $"SELECT Value FROM CacheElement WHERE Key = ? AND {expiryPredicate} AND TypeName = ?",
-                    [key, boxedNowTicks, type.AssemblyQualifiedName!]));
-            }
-
-            sqlStatements.Add((
-                $"SELECT Value FROM CacheElement WHERE Key = ? AND {expiryPredicate} AND TypeName = ?",
-                [key, boxedNowTicks, type.FullName!]));
-        }
-
-        sqlStatements.Add((
-            $"SELECT Value FROM CacheElement WHERE Key = ? AND {expiryPredicate}",
-            [key, boxedNowTicks]));
-
-        foreach (var (sql, args) in sqlStatements)
-        {
-            try
-            {
-                var value = await _connection.ExecuteScalarAsync<byte[]?>(sql, args).ConfigureAwait(false);
-                if (value != null)
+                var hit = await TryExecuteLegacyAsync(TypedSql, [key, boxedNowTicks, type.AssemblyQualifiedName!]).ConfigureAwait(false);
+                if (hit is not null)
                 {
-                    return value;
+                    return hit;
                 }
             }
-            catch
+
+            var fullNameHit = await TryExecuteLegacyAsync(TypedSql, [key, boxedNowTicks, type.FullName!]).ConfigureAwait(false);
+            if (fullNameHit is not null)
             {
-                // Try next form — table/columns may not exist in newer DBs.
+                return fullNameHit;
             }
         }
 
-        return null;
+        return await TryExecuteLegacyAsync(UntypedSql, [key, boxedNowTicks]).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -166,6 +152,26 @@ internal sealed class SqliteAkavacheConnection : IAkavacheConnection
     /// <inheritdoc/>
     public ValueTask DisposeAsync() =>
         new(CloseAsync());
+
+    /// <summary>
+    /// Executes a single legacy SELECT statement, swallowing "table/column not found" style
+    /// exceptions so the caller can fall through to the next query form.
+    /// </summary>
+    /// <param name="sql">The legacy SQL statement.</param>
+    /// <param name="args">Bound parameters.</param>
+    /// <returns>The matching blob, or <see langword="null"/> if the query failed or returned no row.</returns>
+    private async Task<byte[]?> TryExecuteLegacyAsync(string sql, object[] args)
+    {
+        try
+        {
+            return await _connection.ExecuteScalarAsync<byte[]?>(sql, args).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Table/columns may not exist in newer DBs — caller falls through to the next form.
+            return null;
+        }
+    }
 
     /// <summary>
     /// Row shape used to drain the result of <c>PRAGMA wal_checkpoint(...)</c>, which returns

--- a/src/Akavache.Sqlite3/SqliteBlobCache.cs
+++ b/src/Akavache.Sqlite3/SqliteBlobCache.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Akavache.Core;
 using Akavache.Helpers;
 using SQLite;
 
@@ -182,7 +183,7 @@ public class SqliteBlobCache : IBlobCache
     public IObservable<Unit> Flush(Type type) =>
         _disposed
             ? IBlobCache.ExceptionHelpers.ObservableThrowObjectDisposedException<Unit>(ClassName)
-            : Observable.Return(Unit.Default);
+            : Akavache.Core.CachedObservables.UnitDefault;
 
     /// <inheritdoc/>
     public IObservable<byte[]?> Get(string key)
@@ -213,9 +214,9 @@ public class SqliteBlobCache : IBlobCache
         var time = DateTimeOffset.UtcNow;
 
         return _initialized.SelectMany((_, _, _) => Connection.QueryAsync<CacheEntry>(x => x.Id != null && (x.ExpiresAt == null || x.ExpiresAt > time) && keys.Contains(x.Id)))
-            .SelectMany(x => x)
+            .SelectMany(static x => x)
             .Where(static x => x.Value is not null && x.Id is not null)
-            .Select(x => new KeyValuePair<string, byte[]>(x.Id!, x.Value!));
+            .Select(static x => new KeyValuePair<string, byte[]>(x.Id!, x.Value!));
     }
 
     /// <inheritdoc/>
@@ -259,9 +260,9 @@ public class SqliteBlobCache : IBlobCache
 
         var time = DateTimeOffset.UtcNow;
         return _initialized.SelectMany((_, _, _) => Connection.QueryAsync<CacheEntry>(x => x.Id != null && (x.ExpiresAt == null || x.ExpiresAt > time) && keys.Contains(x.Id) && x.TypeName == type.FullName))
-            .SelectMany(x => x)
+            .SelectMany(static x => x)
             .Where(static x => x.Value is not null && x.Id is not null)
-            .Select(x => new KeyValuePair<string, byte[]>(x.Id!, x.Value!));
+            .Select(static x => new KeyValuePair<string, byte[]>(x.Id!, x.Value!));
     }
 
     /// <inheritdoc/>
@@ -279,9 +280,9 @@ public class SqliteBlobCache : IBlobCache
 
         var time = DateTimeOffset.UtcNow;
         return _initialized.SelectMany((_, _, _) => Connection.QueryAsync<CacheEntry>(x => x.Id != null && (x.ExpiresAt == null || x.ExpiresAt > time) && x.TypeName == type.FullName))
-            .SelectMany(x => x)
+            .SelectMany(static x => x)
             .Where(static x => x.Value is not null && x.Id is not null)
-            .Select(x => new KeyValuePair<string, byte[]>(x.Id!, x.Value!));
+            .Select(static x => new KeyValuePair<string, byte[]>(x.Id!, x.Value!));
     }
 
     /// <inheritdoc/>
@@ -314,9 +315,9 @@ public class SqliteBlobCache : IBlobCache
 
         var time = DateTimeOffset.UtcNow;
         return _initialized.SelectMany((_, _, _) => Connection.QueryAsync<CacheEntry>(x => x.Id != null && (x.ExpiresAt == null || x.ExpiresAt > time) && x.TypeName == type.FullName))
-            .SelectMany(x => x)
+            .SelectMany(static x => x)
             .Where(static x => x.Id is not null)
-            .Select(x => x.Id!);
+            .Select(static x => x.Id!);
     }
 
     /// <inheritdoc/>
@@ -334,7 +335,7 @@ public class SqliteBlobCache : IBlobCache
 
         var time = DateTimeOffset.UtcNow;
         return _initialized.SelectMany((_, _, _) => Connection.QueryAsync<CacheEntry>(x => x.Id != null && (x.ExpiresAt == null || x.ExpiresAt > time) && keys.Contains(x.Id)))
-            .SelectMany(x => x)
+            .SelectMany(static x => x)
             .Where(static x => x.Id is not null)
             .Select(static x => (Key: x.Id!, Time: (DateTimeOffset?)x.CreatedAt));
     }
@@ -353,11 +354,22 @@ public class SqliteBlobCache : IBlobCache
         }
 
         var time = DateTimeOffset.UtcNow;
-        return _initialized.SelectMany((_, _, _) => Connection.QueryAsync<CacheEntry>(x => x.Id != null && (x.ExpiresAt == null || x.ExpiresAt > time) && x.Id == key))
-            .SelectMany(x => x)
-            .Where(static x => x.Id is not null)
-            .Select(static x => (DateTimeOffset?)x.CreatedAt)
-            .DefaultIfEmpty();
+
+        // Single async projection replaces the 4-operator Rx chain (SelectMany/SelectMany/Where/Select/DefaultIfEmpty).
+        // Defensive null-Id filter is preserved because backends with BypassPredicate=true can return null-Id rows.
+        return _initialized.SelectMany(async (_, _, _) =>
+        {
+            var results = await Connection.QueryAsync<CacheEntry>(x => x.Id != null && (x.ExpiresAt == null || x.ExpiresAt > time) && x.Id == key).ConfigureAwait(false);
+            for (var i = 0; i < results.Count; i++)
+            {
+                if (results[i].Id is not null)
+                {
+                    return (DateTimeOffset?)results[i].CreatedAt;
+                }
+            }
+
+            return null;
+        });
     }
 
     /// <inheritdoc/>
@@ -380,7 +392,7 @@ public class SqliteBlobCache : IBlobCache
 
         var time = DateTimeOffset.UtcNow;
         return _initialized.SelectMany((_, _, _) => Connection.QueryAsync<CacheEntry>(x => x.Id != null && (x.ExpiresAt == null || x.ExpiresAt > time) && keys.Contains(x.Id) && x.TypeName == type.FullName))
-            .SelectMany(x => x)
+            .SelectMany(static x => x)
             .Where(static x => x.Id is not null)
             .Select(static x => (Key: x.Id!, Time: (DateTimeOffset?)x.CreatedAt));
     }
@@ -404,11 +416,22 @@ public class SqliteBlobCache : IBlobCache
         }
 
         var time = DateTimeOffset.UtcNow;
-        return _initialized.SelectMany((_, _, _) => Connection.QueryAsync<CacheEntry>(x => x.Id != null && (x.ExpiresAt == null || x.ExpiresAt > time) && x.Id == key && x.TypeName == type.FullName))
-            .SelectMany(x => x)
-            .Where(static x => x.Id is not null)
-            .Select(static x => (DateTimeOffset?)x.CreatedAt)
-            .DefaultIfEmpty();
+
+        // Single async projection replaces the 4-operator Rx chain (SelectMany/SelectMany/Where/Select/DefaultIfEmpty).
+        // Defensive null-Id filter is preserved because backends with BypassPredicate=true can return null-Id rows.
+        return _initialized.SelectMany(async (_, _, _) =>
+        {
+            var results = await Connection.QueryAsync<CacheEntry>(x => x.Id != null && (x.ExpiresAt == null || x.ExpiresAt > time) && x.Id == key && x.TypeName == type.FullName).ConfigureAwait(false);
+            for (var i = 0; i < results.Count; i++)
+            {
+                if (results[i].Id is not null)
+                {
+                    return (DateTimeOffset?)results[i].CreatedAt;
+                }
+            }
+
+            return null;
+        });
     }
 
     /// <inheritdoc/>
@@ -426,22 +449,24 @@ public class SqliteBlobCache : IBlobCache
 
         var expiry = (absoluteExpiration ?? DateTimeOffset.MaxValue).UtcDateTime;
 
+        // Hoist DateTime.Now out of the per-entry projection — a single wall-clock read per
+        // batch is what the old code intended anyway, and this avoids a syscall per item.
+        var createdAt = DateTime.Now;
+
         return _initialized.SelectMany(
             async (_, _, _) =>
             {
-                var entries = keyValuePairs.Select(x => new CacheEntry { CreatedAt = DateTime.Now, Id = x.Key, Value = x.Value, ExpiresAt = expiry });
-
                 await Connection.RunInTransactionAsync(tx =>
                 {
-                    foreach (var entry in entries)
+                    foreach (var kvp in keyValuePairs)
                     {
-                        tx.InsertOrReplace(entry);
+                        tx.InsertOrReplace(new CacheEntry(kvp.Key, typeName: null, kvp.Value, createdAt, expiry));
                     }
                 }).ConfigureAwait(false);
 
                 return Unit.Default;
             })
-            .Select(_ => Unit.Default);
+            .SelectUnit();
     }
 
     /// <inheritdoc/>
@@ -467,9 +492,12 @@ public class SqliteBlobCache : IBlobCache
 
         var expiry = (absoluteExpiration ?? DateTimeOffset.MaxValue).UtcDateTime;
 
+        // Hoist DateTime.Now and the reflected type-name string out of the per-entry projection.
+        var createdAt = DateTime.Now;
+        var typeName = type.FullName;
+
         return _initialized.SelectMany(async (_, _, _) =>
             {
-                var entries = keyValuePairs.Select(x => new CacheEntry { CreatedAt = DateTime.Now, Id = x.Key, Value = x.Value, ExpiresAt = expiry, TypeName = type.FullName });
                 try
                 {
                     await Connection.RunInTransactionAsync(tx =>
@@ -479,7 +507,7 @@ public class SqliteBlobCache : IBlobCache
                             return;
                         }
 
-                        foreach (var entry in entries)
+                        foreach (var kvp in keyValuePairs)
                         {
                             try
                             {
@@ -488,7 +516,7 @@ public class SqliteBlobCache : IBlobCache
                                     return;
                                 }
 
-                                tx.InsertOrReplace(entry);
+                                tx.InsertOrReplace(new CacheEntry(kvp.Key, typeName, kvp.Value, createdAt, expiry));
                             }
                             catch (Exception)
                             {
@@ -514,7 +542,7 @@ public class SqliteBlobCache : IBlobCache
 
                 return Unit.Default;
             })
-            .Select(_ => Unit.Default);
+            .SelectUnit();
     }
 
     /// <inheritdoc/>

--- a/src/Akavache.SystemTextJson.Bson/SystemJsonBsonSerializer.cs
+++ b/src/Akavache.SystemTextJson.Bson/SystemJsonBsonSerializer.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Akavache.Helpers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Bson;
 
@@ -56,8 +57,9 @@ public partial class SystemJsonBsonSerializer : ISerializer
             return false;
         }
 
-        var dataString = Encoding.UTF8.GetString(data);
-        return !(dataString.TrimStart().StartsWith("{") || dataString.TrimStart().StartsWith("["));
+        // If the payload starts with a JSON opener (after whitespace), it's probably JSON,
+        // not BSON. Byte-level probe — zero allocations.
+        return !BinaryHelpers.StartsWithJsonOpener(data);
     }
 
     /// <summary>
@@ -217,7 +219,7 @@ public partial class SystemJsonBsonSerializer : ISerializer
             var jsonString = System.Text.Json.JsonSerializer.Serialize(wrapper, options);
             var token = Newtonsoft.Json.Linq.JToken.Parse(jsonString);
 
-            using MemoryStream ms = new();
+            using MemoryStream ms = new(capacity: 256);
             using BsonDataWriter writer = new(ms);
             token.WriteTo(writer);
             return ms.ToArray();
@@ -243,7 +245,7 @@ public partial class SystemJsonBsonSerializer : ISerializer
     {
         try
         {
-            using BsonDataReader reader = new(new MemoryStream(bytes));
+            using BsonDataReader reader = new(new MemoryStream(bytes, writable: false));
 
             if (ForcedDateTimeKind.HasValue)
             {

--- a/src/Akavache.V10toV11/V10MigrationService.cs
+++ b/src/Akavache.V10toV11/V10MigrationService.cs
@@ -270,7 +270,7 @@ internal static class V10MigrationService
                     return null;
                 }
             })
-            .FirstOrDefault(t => t != null);
+            .FirstOrDefault(static t => t != null);
     }
 
     /// <summary>

--- a/src/tests/Akavache.Tests/BinaryHelpersTests.cs
+++ b/src/tests/Akavache.Tests/BinaryHelpersTests.cs
@@ -291,4 +291,58 @@ public class BinaryHelpersTests
             await Assert.That(actual).IsEqualTo(expected);
         }
     }
+
+    /// <summary>
+    /// Verifies <see cref="BinaryHelpers.StartsWithJsonOpener"/> returns <see langword="false"/>
+    /// for a null input without throwing.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task StartsWithJsonOpenerShouldReturnFalseForNullInput() =>
+        await Assert.That(BinaryHelpers.StartsWithJsonOpener(null!)).IsFalse();
+
+    /// <summary>
+    /// Verifies <see cref="BinaryHelpers.StartsWithJsonOpener"/> returns <see langword="false"/>
+    /// for an empty buffer (no non-whitespace byte to classify).
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task StartsWithJsonOpenerShouldReturnFalseForEmptyBuffer() =>
+        await Assert.That(BinaryHelpers.StartsWithJsonOpener([])).IsFalse();
+
+    /// <summary>
+    /// Verifies <see cref="BinaryHelpers.StartsWithJsonOpener"/> returns <see langword="false"/>
+    /// for a buffer containing only ASCII whitespace (no JSON opener to find).
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task StartsWithJsonOpenerShouldReturnFalseForWhitespaceOnly() =>
+        await Assert.That(BinaryHelpers.StartsWithJsonOpener([(byte)' ', (byte)'\t', (byte)'\n', (byte)'\r'])).IsFalse();
+
+    /// <summary>
+    /// Verifies <see cref="BinaryHelpers.StartsWithJsonOpener"/> recognises the two JSON
+    /// opener bytes after skipping leading ASCII whitespace.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task StartsWithJsonOpenerShouldRecogniseJsonOpenersAfterWhitespace()
+    {
+        await Assert.That(BinaryHelpers.StartsWithJsonOpener([(byte)'{', (byte)'}'])).IsTrue();
+        await Assert.That(BinaryHelpers.StartsWithJsonOpener([(byte)'[', (byte)']'])).IsTrue();
+        await Assert.That(BinaryHelpers.StartsWithJsonOpener([(byte)' ', (byte)' ', (byte)'{'])).IsTrue();
+        await Assert.That(BinaryHelpers.StartsWithJsonOpener([(byte)'\t', (byte)'\n', (byte)'\r', (byte)'['])).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies <see cref="BinaryHelpers.StartsWithJsonOpener"/> rejects a non-JSON payload
+    /// whose first non-whitespace byte is neither <c>{</c> nor <c>[</c>.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task StartsWithJsonOpenerShouldRejectNonJsonPayloads()
+    {
+        await Assert.That(BinaryHelpers.StartsWithJsonOpener([0x05, 0x00, 0x00, 0x00])).IsFalse();
+        await Assert.That(BinaryHelpers.StartsWithJsonOpener([(byte)'"'])).IsFalse();
+        await Assert.That(BinaryHelpers.StartsWithJsonOpener([(byte)' ', (byte)'x'])).IsFalse();
+    }
 }

--- a/src/tests/Akavache.Tests/CacheEntryTests.cs
+++ b/src/tests/Akavache.Tests/CacheEntryTests.cs
@@ -188,4 +188,116 @@ public class CacheEntryTests
         CacheEntry b = new() { Id = "k", TypeName = "t", Value = null };
         await Assert.That(a.GetHashCode()).IsEqualTo(b.GetHashCode());
     }
+
+    /// <summary>
+    /// Tests that the parameterised constructor populates every field verbatim.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task ParameterisedConstructorShouldPopulateAllFields()
+    {
+        var created = new DateTimeOffset(2026, 3, 4, 5, 6, 7, TimeSpan.Zero);
+        var expires = new DateTimeOffset(2026, 4, 5, 6, 7, 8, TimeSpan.Zero);
+        byte[] payload = [1, 2, 3];
+
+        var entry = new CacheEntry("my-key", "My.Type", payload, created, expires);
+
+        await Assert.That(entry.Id).IsEqualTo("my-key");
+        await Assert.That(entry.TypeName).IsEqualTo("My.Type");
+        await Assert.That(entry.Value).IsEqualTo(payload);
+        await Assert.That(entry.CreatedAt).IsEqualTo(created);
+        await Assert.That(entry.ExpiresAt).IsEqualTo(expires);
+    }
+
+    /// <summary>
+    /// Tests that the parameterised constructor accepts null typeName, null value, and null expiry.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task ParameterisedConstructorShouldAcceptNullOptionalFields()
+    {
+        var created = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var entry = new CacheEntry("key", typeName: null, value: null, created, expiresAt: null);
+
+        await Assert.That(entry.Id).IsEqualTo("key");
+        await Assert.That(entry.TypeName).IsNull();
+        await Assert.That(entry.Value).IsNull();
+        await Assert.That(entry.ExpiresAt).IsNull();
+    }
+
+    /// <summary>
+    /// Tests that <see cref="CacheEntry.ValueEquals"/> returns true when both buffers are the same reference.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task ValueEqualsShouldReturnTrueForSameReference()
+    {
+        byte[] buf = [1, 2, 3];
+        await Assert.That(CacheEntry.ValueEquals(buf, buf)).IsTrue();
+    }
+
+    /// <summary>
+    /// Tests that <see cref="CacheEntry.ValueEquals"/> returns true when both buffers are null.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task ValueEqualsShouldReturnTrueForBothNull() =>
+        await Assert.That(CacheEntry.ValueEquals(null, null)).IsTrue();
+
+    /// <summary>
+    /// Tests that <see cref="CacheEntry.ValueEquals"/> returns false when exactly one buffer is null.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task ValueEqualsShouldReturnFalseWhenOnlyOneIsNull()
+    {
+        byte[] buf = [1];
+        await Assert.That(CacheEntry.ValueEquals(buf, null)).IsFalse();
+        await Assert.That(CacheEntry.ValueEquals(null, buf)).IsFalse();
+    }
+
+    /// <summary>
+    /// Tests that <see cref="CacheEntry.ValueEquals"/> returns true for distinct buffers with identical contents.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task ValueEqualsShouldReturnTrueForDistinctBuffersWithEqualContent()
+    {
+        byte[] a = [1, 2, 3, 4, 5];
+        byte[] b = [1, 2, 3, 4, 5];
+        await Assert.That(CacheEntry.ValueEquals(a, b)).IsTrue();
+    }
+
+    /// <summary>
+    /// Tests that <see cref="CacheEntry.ValueEquals"/> returns false for buffers of equal length but differing content.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task ValueEqualsShouldReturnFalseForEqualLengthDifferentContent()
+    {
+        byte[] a = [1, 2, 3];
+        byte[] b = [1, 2, 4];
+        await Assert.That(CacheEntry.ValueEquals(a, b)).IsFalse();
+    }
+
+    /// <summary>
+    /// Tests that <see cref="CacheEntry.ValueEquals"/> returns false for buffers of different length.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task ValueEqualsShouldReturnFalseForDifferentLengths()
+    {
+        byte[] a = [1, 2, 3];
+        byte[] b = [1, 2];
+        await Assert.That(CacheEntry.ValueEquals(a, b)).IsFalse();
+    }
+
+    /// <summary>
+    /// Tests that <see cref="CacheEntry.ValueEquals"/> treats two empty buffers as equal.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task ValueEqualsShouldReturnTrueForTwoEmptyBuffers() =>
+        await Assert.That(CacheEntry.ValueEquals([], [])).IsTrue();
 }

--- a/src/tests/Akavache.Tests/InMemoryBlobCacheBaseTests.cs
+++ b/src/tests/Akavache.Tests/InMemoryBlobCacheBaseTests.cs
@@ -1363,6 +1363,165 @@ public class InMemoryBlobCacheBaseTests
     }
 
     /// <summary>
+    /// Verifies <see cref="InMemoryBlobCacheBase.RemoveKeyFromTypeIndexFast"/> removes the key
+    /// from the single type bucket tracked by <c>keyToType</c> and clears the
+    /// reverse-map entry, without touching unrelated buckets.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task RemoveKeyFromTypeIndexFastShouldRemoveFromTrackedBucketOnly()
+    {
+        Dictionary<Type, HashSet<string>> typeIndex = new()
+        {
+            [typeof(string)] = ["k1", "k2"],
+            [typeof(int)] = ["k3"],
+        };
+        Dictionary<string, Type> keyToType = new(StringComparer.Ordinal)
+        {
+            ["k1"] = typeof(string),
+            ["k2"] = typeof(string),
+            ["k3"] = typeof(int),
+        };
+
+        InMemoryBlobCacheBase.RemoveKeyFromTypeIndexFast(typeIndex, keyToType, "k1");
+
+        await Assert.That(typeIndex[typeof(string)]).DoesNotContain("k1");
+        await Assert.That(typeIndex[typeof(string)]).Contains("k2");
+        await Assert.That(typeIndex[typeof(int)]).Contains("k3");
+        await Assert.That(keyToType).DoesNotContainKey("k1");
+        await Assert.That(keyToType).ContainsKey("k2");
+    }
+
+    /// <summary>
+    /// Verifies <see cref="InMemoryBlobCacheBase.RemoveKeyFromTypeIndexFast"/> is a no-op when
+    /// the key was never tracked by the reverse map (e.g. it was inserted via an untyped <c>Insert</c>).
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task RemoveKeyFromTypeIndexFastShouldNoOpForUntrackedKey()
+    {
+        Dictionary<Type, HashSet<string>> typeIndex = new()
+        {
+            [typeof(string)] = ["tracked"],
+        };
+        Dictionary<string, Type> keyToType = new(StringComparer.Ordinal)
+        {
+            ["tracked"] = typeof(string),
+        };
+
+        InMemoryBlobCacheBase.RemoveKeyFromTypeIndexFast(typeIndex, keyToType, "untracked");
+
+        await Assert.That(typeIndex[typeof(string)]).Contains("tracked");
+        await Assert.That(keyToType).ContainsKey("tracked");
+    }
+
+    /// <summary>
+    /// Verifies <see cref="InMemoryBlobCacheBase.RemoveKeyFromTypeIndexFast"/> tolerates the
+    /// case where the reverse map points to a type that has already been evicted from
+    /// <c>typeIndex</c> — it still cleans the reverse-map entry.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task RemoveKeyFromTypeIndexFastShouldClearReverseMapWhenTypeBucketMissing()
+    {
+        Dictionary<Type, HashSet<string>> typeIndex = [];
+        Dictionary<string, Type> keyToType = new(StringComparer.Ordinal)
+        {
+            ["k1"] = typeof(string),
+        };
+
+        InMemoryBlobCacheBase.RemoveKeyFromTypeIndexFast(typeIndex, keyToType, "k1");
+
+        await Assert.That(keyToType).DoesNotContainKey("k1");
+    }
+
+    /// <summary>
+    /// Verifies <see cref="InMemoryBlobCacheBase.VacuumExpiredEntriesFast"/> removes expired
+    /// entries from the cache, prunes the corresponding entries from both <c>typeIndex</c>
+    /// and <c>keyToType</c>, and preserves valid entries untouched.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task VacuumExpiredEntriesFastShouldRemoveExpiredAndPruneIndexes()
+    {
+        DateTimeOffset now = new(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        Dictionary<string, CacheEntry> cache = new(StringComparer.Ordinal)
+        {
+            ["expired"] = new() { Id = "expired", ExpiresAt = now.AddMinutes(-1).UtcDateTime, TypeName = "System.String" },
+            ["valid"] = new() { Id = "valid", ExpiresAt = now.AddHours(1).UtcDateTime, TypeName = "System.String" },
+        };
+        Dictionary<Type, HashSet<string>> typeIndex = new()
+        {
+            [typeof(string)] = new(StringComparer.Ordinal) { "expired", "valid" },
+        };
+        Dictionary<string, Type> keyToType = new(StringComparer.Ordinal)
+        {
+            ["expired"] = typeof(string),
+            ["valid"] = typeof(string),
+        };
+
+        InMemoryBlobCacheBase.VacuumExpiredEntriesFast(cache, typeIndex, keyToType, now);
+
+        await Assert.That(cache).DoesNotContainKey("expired");
+        await Assert.That(cache).ContainsKey("valid");
+        await Assert.That(typeIndex[typeof(string)]).DoesNotContain("expired");
+        await Assert.That(typeIndex[typeof(string)]).Contains("valid");
+        await Assert.That(keyToType).DoesNotContainKey("expired");
+        await Assert.That(keyToType).ContainsKey("valid");
+    }
+
+    /// <summary>
+    /// Verifies <see cref="InMemoryBlobCacheBase.VacuumExpiredEntriesFast"/> is a no-op when
+    /// nothing is expired — cache, type-index, and reverse-map are all left untouched.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task VacuumExpiredEntriesFastShouldBeNoOpWhenNothingExpired()
+    {
+        DateTimeOffset now = new(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        Dictionary<string, CacheEntry> cache = new(StringComparer.Ordinal)
+        {
+            ["valid"] = new() { Id = "valid", ExpiresAt = now.AddHours(1).UtcDateTime },
+        };
+        Dictionary<Type, HashSet<string>> typeIndex = new()
+        {
+            [typeof(string)] = new(StringComparer.Ordinal) { "valid" },
+        };
+        Dictionary<string, Type> keyToType = new(StringComparer.Ordinal)
+        {
+            ["valid"] = typeof(string),
+        };
+
+        InMemoryBlobCacheBase.VacuumExpiredEntriesFast(cache, typeIndex, keyToType, now);
+
+        await Assert.That(cache).ContainsKey("valid");
+        await Assert.That(typeIndex[typeof(string)]).Contains("valid");
+        await Assert.That(keyToType).ContainsKey("valid");
+    }
+
+    /// <summary>
+    /// Verifies <see cref="InMemoryBlobCacheBase.VacuumExpiredEntriesFast"/> handles expired
+    /// entries whose keys were never typed (never tracked in <c>keyToType</c>) —
+    /// the cache row is still removed and no exception is thrown.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task VacuumExpiredEntriesFastShouldRemoveUntrackedExpiredEntries()
+    {
+        DateTimeOffset now = new(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        Dictionary<string, CacheEntry> cache = new(StringComparer.Ordinal)
+        {
+            ["expired-untyped"] = new() { Id = "expired-untyped", ExpiresAt = now.AddMinutes(-1).UtcDateTime },
+        };
+        Dictionary<Type, HashSet<string>> typeIndex = [];
+        Dictionary<string, Type> keyToType = new(StringComparer.Ordinal);
+
+        InMemoryBlobCacheBase.VacuumExpiredEntriesFast(cache, typeIndex, keyToType, now);
+
+        await Assert.That(cache).DoesNotContainKey("expired-untyped");
+    }
+
+    /// <summary>
     /// Creates a new <see cref="InMemoryBlobCache"/> using the immediate scheduler and System.Text.Json serializer.
     /// </summary>
     /// <returns>A new in-memory blob cache instance.</returns>

--- a/src/tests/Akavache.Tests/InMemoryBlobCacheBaseTests.cs
+++ b/src/tests/Akavache.Tests/InMemoryBlobCacheBaseTests.cs
@@ -1572,6 +1572,35 @@ public class InMemoryBlobCacheBaseTests
     }
 
     /// <summary>
+    /// Verifies <see cref="InMemoryBlobCacheBase.Invalidate(IEnumerable{string})"/> still
+    /// removes entries when handed an iterator-based <see cref="IEnumerable{T}"/> that is not
+    /// an <see cref="ICollection{T}"/> — drives the false branch of the fast-path
+    /// <c>ICollection</c> type-pattern guard and exercises the regular materialisation loop.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task InvalidateIEnumerableShouldHandleNonICollectionSource()
+    {
+        await using var cache = CreateCache();
+        await cache.Insert("drop-1", [1]);
+        await cache.Insert("drop-2", [2]);
+        await cache.Insert("keep", [3]);
+
+        await cache.Invalidate(IteratorKeys());
+
+        var keys = (await cache.GetAllKeys().ToList()).ToList();
+        await Assert.That(keys).Contains("keep");
+        await Assert.That(keys).DoesNotContain("drop-1");
+        await Assert.That(keys).DoesNotContain("drop-2");
+
+        static IEnumerable<string> IteratorKeys()
+        {
+            yield return "drop-1";
+            yield return "drop-2";
+        }
+    }
+
+    /// <summary>
     /// Verifies the bulk typed <see cref="InMemoryBlobCacheBase.Insert(IEnumerable{KeyValuePair{string, byte[]}}, Type, DateTimeOffset?)"/>
     /// evicts a key from its previous type bucket when it is re-inserted under a new type,
     /// preserving the "one type per key" invariant that the O(1) reverse index depends on.

--- a/src/tests/Akavache.Tests/InMemoryBlobCacheBaseTests.cs
+++ b/src/tests/Akavache.Tests/InMemoryBlobCacheBaseTests.cs
@@ -1522,6 +1522,116 @@ public class InMemoryBlobCacheBaseTests
     }
 
     /// <summary>
+    /// Verifies the untyped <see cref="InMemoryBlobCacheBase.Insert(IEnumerable{KeyValuePair{string, byte[]}}, DateTimeOffset?)"/>
+    /// overload short-circuits to the cached unit observable when handed an empty
+    /// <see cref="ICollection{T}"/>, without scheduling any work on the thread pool.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task InsertIEnumerableShouldEarlyExitOnEmptyCollection()
+    {
+        await using var cache = CreateCache();
+
+        await cache.Insert([]);
+
+        var keys = await cache.GetAllKeys().ToList();
+        await Assert.That(keys).IsEmpty();
+    }
+
+    /// <summary>
+    /// Verifies the typed <see cref="InMemoryBlobCacheBase.Insert(IEnumerable{KeyValuePair{string, byte[]}}, Type, DateTimeOffset?)"/>
+    /// overload short-circuits to the cached unit observable on empty input.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task TypedInsertIEnumerableShouldEarlyExitOnEmptyCollection()
+    {
+        await using var cache = CreateCache();
+
+        await cache.Insert([], typeof(string));
+
+        var typedKeys = await cache.GetAllKeys(typeof(string)).ToList();
+        await Assert.That(typedKeys).IsEmpty();
+    }
+
+    /// <summary>
+    /// Verifies <see cref="InMemoryBlobCacheBase.Invalidate(IEnumerable{string})"/> short-circuits
+    /// on an empty key set — the cache stays untouched and no observable start work runs.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task InvalidateIEnumerableShouldEarlyExitOnEmptyCollection()
+    {
+        await using var cache = CreateCache();
+        await cache.Insert("survivor", [9]);
+
+        await cache.Invalidate([]);
+
+        var keys = await cache.GetAllKeys().ToList();
+        await Assert.That(keys).Contains("survivor");
+    }
+
+    /// <summary>
+    /// Verifies the bulk typed <see cref="InMemoryBlobCacheBase.Insert(IEnumerable{KeyValuePair{string, byte[]}}, Type, DateTimeOffset?)"/>
+    /// evicts a key from its previous type bucket when it is re-inserted under a new type,
+    /// preserving the "one type per key" invariant that the O(1) reverse index depends on.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task BulkTypedInsertShouldEvictKeyFromPreviousTypeBucket()
+    {
+        await using var cache = CreateCache();
+
+        // Arrange: land "k1" in the string bucket first.
+        await cache.Insert([new KeyValuePair<string, byte[]>("k1", [1])], typeof(string));
+        await Assert.That((await cache.GetAllKeys(typeof(string)).ToList()).ToList()).Contains("k1");
+
+        // Act: re-insert the same key under a different type, in the bulk path.
+        await cache.Insert([new KeyValuePair<string, byte[]>("k1", [2])], typeof(int));
+
+        // Assert: k1 is now only in the int bucket.
+        await Assert.That((await cache.GetAllKeys(typeof(string)).ToList()).ToList()).DoesNotContain("k1");
+        await Assert.That((await cache.GetAllKeys(typeof(int)).ToList()).ToList()).Contains("k1");
+    }
+
+    /// <summary>
+    /// Verifies the single-key typed <see cref="InMemoryBlobCacheBase.Insert(string, byte[], Type, DateTimeOffset?)"/>
+    /// evicts a key from its previous type bucket when it is re-inserted under a new type.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task SingleKeyTypedInsertShouldEvictKeyFromPreviousTypeBucket()
+    {
+        await using var cache = CreateCache();
+
+        await cache.Insert("k1", [1], typeof(string));
+        await Assert.That((await cache.GetAllKeys(typeof(string)).ToList()).ToList()).Contains("k1");
+
+        await cache.Insert("k1", [2], typeof(int));
+
+        await Assert.That((await cache.GetAllKeys(typeof(string)).ToList()).ToList()).DoesNotContain("k1");
+        await Assert.That((await cache.GetAllKeys(typeof(int)).ToList()).ToList()).Contains("k1");
+    }
+
+    /// <summary>
+    /// Verifies the single-key typed <see cref="InMemoryBlobCacheBase.Insert(string, byte[], Type, DateTimeOffset?)"/>
+    /// is a no-op for the "same type, same key" path — the reverse index remains consistent
+    /// and the key stays in its existing bucket.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task SingleKeyTypedInsertReplayingSameTypeShouldRetainBucketMembership()
+    {
+        await using var cache = CreateCache();
+
+        await cache.Insert("k1", [1], typeof(string));
+        await cache.Insert("k1", [2], typeof(string));
+
+        var keys = await cache.GetAllKeys(typeof(string)).ToList();
+        await Assert.That(keys.ToList()).Contains("k1");
+    }
+
+    /// <summary>
     /// Creates a new <see cref="InMemoryBlobCache"/> using the immediate scheduler and System.Text.Json serializer.
     /// </summary>
     /// <returns>A new in-memory blob cache instance.</returns>

--- a/src/tests/Akavache.Tests/KeyMetadataTests.cs
+++ b/src/tests/Akavache.Tests/KeyMetadataTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Reflection.Emit;
+using Akavache.Core;
+
+namespace Akavache.Tests;
+
+/// <summary>
+/// Tests for <see cref="KeyMetadata"/> / <see cref="KeyMetadata{T}"/>. The static generic class
+/// materialises its reflection strings exactly once per closed type, so exercising the
+/// null-fallback branches requires the non-generic <see cref="KeyMetadata"/> companion's
+/// <c>Build*</c> helpers that take an explicit <see cref="Type"/>.
+/// </summary>
+[Category("Akavache")]
+public class KeyMetadataTests
+{
+    /// <summary>
+    /// Verifies <see cref="KeyMetadata.BuildFullName"/> returns <see cref="Type.FullName"/>
+    /// verbatim for an ordinary concrete type whose full name is non-null.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task BuildFullNameShouldReturnFullNameForConcreteType() =>
+        await Assert.That(KeyMetadata.BuildFullName(typeof(string))).IsEqualTo("System.String");
+
+    /// <summary>
+    /// Verifies <see cref="KeyMetadata.BuildFullName"/> falls back to the short type name
+    /// when <see cref="Type.FullName"/> is null. Generic type parameters reflected from an open
+    /// generic definition are the standard example: their <c>FullName</c> is null by design.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task BuildFullNameShouldFallBackToNameWhenFullNameIsNull()
+    {
+        // typeof(List<>).GetGenericArguments()[0] is the generic parameter "T" — the runtime
+        // reports FullName = null, Name = "T" for it, which drives the ?? fallback branch.
+        var genericParameter = typeof(List<>).GetGenericArguments()[0];
+
+        await Assert.That(genericParameter.FullName).IsNull();
+        await Assert.That(KeyMetadata.BuildFullName(genericParameter)).IsEqualTo("T");
+    }
+
+    /// <summary>
+    /// Verifies <see cref="KeyMetadata.BuildAssemblyQualifiedShortName"/> produces the
+    /// <c>Assembly.Name + "." + Type.Name</c> form for an ordinary runtime type.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task BuildAssemblyQualifiedShortNameShouldCombineAssemblyAndTypeName()
+    {
+        var result = KeyMetadata.BuildAssemblyQualifiedShortName(typeof(string));
+
+        // System.String lives in the core library — the exact assembly simple name varies
+        // across runtimes ("System.Private.CoreLib", "mscorlib") but it is always non-null
+        // and always ends with ".String" here.
+        await Assert.That(result).EndsWith(".String");
+        await Assert.That(result).DoesNotStartWith(".");
+    }
+
+    /// <summary>
+    /// Verifies <see cref="KeyMetadata.BuildAssemblyQualifiedShortName"/> collapses to just the
+    /// short type name when the declaring assembly has no simple name. Exercised via a shim
+    /// <see cref="Type"/> whose Assembly reports a null <see cref="AssemblyName.Name"/>.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task BuildAssemblyQualifiedShortNameShouldFallBackWhenAssemblyNameIsNull()
+    {
+        // We can't easily construct a Type whose Assembly.GetName().Name is truly null from
+        // user code, but we can exercise the equivalent fallback path by asking BuildShortName
+        // on a type whose assembly simple name is empty/whitespace-ish via a dynamic assembly.
+        var asmName = new AssemblyName("dyn-asm-for-keymetadata-tests");
+        var asm = AssemblyBuilder.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.Run);
+        var module = asm.DefineDynamicModule("m");
+        var typeBuilder = module.DefineType("DynType", TypeAttributes.Public);
+        var dynType = typeBuilder.CreateType()!;
+
+        // Sanity: the dynamic assembly's simple name is non-null here — so this test drives
+        // the true branch of the pattern match, confirming it produces the concatenated form.
+        var result = KeyMetadata.BuildAssemblyQualifiedShortName(dynType);
+        await Assert.That(result).IsEqualTo("dyn-asm-for-keymetadata-tests.DynType");
+
+        // And now the null-simple-name fallback: call BuildAssemblyQualifiedShortName on a
+        // shim type via a custom Type subclass that reports a null assembly simple name.
+        var shimType = new NullAssemblyNameShimType("ShimmedType");
+        var shimResult = KeyMetadata.BuildAssemblyQualifiedShortName(shimType);
+        await Assert.That(shimResult).IsEqualTo("ShimmedType");
+    }
+
+    /// <summary>
+    /// Verifies the static <see cref="KeyMetadata{T}"/> cache fields are populated exactly once
+    /// per closed generic and line up with the <see cref="KeyMetadata"/> helper outputs for the
+    /// same type.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task KeyMetadataGenericFieldsShouldMatchHelperOutputs()
+    {
+        await Assert.That(KeyMetadata<string>.FullName).IsEqualTo(KeyMetadata.BuildFullName(typeof(string)));
+        await Assert.That(KeyMetadata<string>.Name).IsEqualTo(nameof(String));
+        await Assert.That(KeyMetadata<string>.AssemblyQualifiedShortName).IsEqualTo(KeyMetadata.BuildAssemblyQualifiedShortName(typeof(string)));
+    }
+
+    /// <summary>
+    /// Minimal <see cref="Type"/> subclass whose <see cref="Assembly"/> reports an
+    /// <see cref="AssemblyName.Name"/> of <see langword="null"/> — the only way to reach the
+    /// second branch of <see cref="KeyMetadata.BuildAssemblyQualifiedShortName"/> from managed
+    /// code without reflecting a distro-specific emitted type.
+    /// </summary>
+    private sealed class NullAssemblyNameShimType(string name) : TypeDelegator(typeof(object))
+    {
+        /// <inheritdoc/>
+        public override string Name => name;
+
+        /// <inheritdoc/>
+        public override Assembly Assembly { get; } = new NullNameAssemblyShim();
+
+        /// <summary>Dynamic assembly shim whose <see cref="AssemblyName.Name"/> is null.</summary>
+        private sealed class NullNameAssemblyShim : Assembly
+        {
+            /// <inheritdoc/>
+            public override AssemblyName GetName() => new() { Name = null };
+
+            /// <inheritdoc/>
+            public override AssemblyName GetName(bool copiedName) => GetName();
+        }
+    }
+}

--- a/src/tests/Akavache.Tests/SqliteAkavacheConnectionTests.cs
+++ b/src/tests/Akavache.Tests/SqliteAkavacheConnectionTests.cs
@@ -441,6 +441,43 @@ public class SqliteAkavacheConnectionTests
     }
 
     /// <summary>
+    /// Verifies <see cref="SqliteAkavacheConnection.TryReadLegacyV10ValueAsync"/> matches a V10
+    /// row whose <c>TypeName</c> was stored in the <see cref="Type.AssemblyQualifiedName"/> form
+    /// (the first legacy probe form tried before <see cref="Type.FullName"/>).
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task TryReadLegacyV10ValueAsyncShouldReturnRowMatchedByAssemblyQualifiedName()
+    {
+        using (Utility.WithEmptyDirectory(out var path))
+        {
+            var dbPath = Path.Combine(path, "legacy.db");
+
+            // Arrange: seed a V10 row whose TypeName column holds the AssemblyQualifiedName
+            // variant. The legacy probe should hit this on its first attempt (the typed AQN
+            // query) before ever falling through to the FullName query.
+            using (SQLiteConnection raw = new(dbPath))
+            {
+                raw.Execute(
+                    "CREATE TABLE CacheElement (Key varchar PRIMARY KEY, TypeName varchar, Value blob, Expiration bigint, CreatedAt bigint)");
+                raw.Execute(
+                    "INSERT INTO CacheElement (Key, TypeName, Value, Expiration, CreatedAt) VALUES (?, ?, ?, ?, ?)",
+                    "aqnKey",
+                    typeof(string).AssemblyQualifiedName,
+                    new byte[] { 1, 2, 3, 4 },
+                    0L,
+                    DateTime.UtcNow.Ticks);
+            }
+
+            await using SqliteAkavacheConnection connection = new(new(dbPath, true));
+
+            var result = await connection.TryReadLegacyV10ValueAsync("aqnKey", DateTimeOffset.UtcNow, typeof(string));
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!).IsEquivalentTo(new byte[] { 1, 2, 3, 4 });
+        }
+    }
+
+    /// <summary>
     /// Verifies <see cref="SqliteAkavacheConnection.TryReadLegacyV10ValueAsync"/> returns null
     /// when the CacheElement table does not exist at all (new database).
     /// </summary>

--- a/src/tests/Akavache.Tests/SqliteAkavacheConnectionTests.cs
+++ b/src/tests/Akavache.Tests/SqliteAkavacheConnectionTests.cs
@@ -718,6 +718,42 @@ public class SqliteAkavacheConnectionTests
     }
 
     /// <summary>
+    /// Verifies the encrypted compilation of <c>SqliteAkavacheConnection</c>'s
+    /// <c>TryReadLegacyV10ValueAsync</c> matches a row whose TypeName column holds the
+    /// <see cref="Type.AssemblyQualifiedName"/> form — drives the first (AQN) query path
+    /// to a successful hit on the encrypted compilation.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task EncryptedConnectionTryReadLegacyV10ValueShouldReturnRowMatchedByAssemblyQualifiedName()
+    {
+        using (Utility.WithEmptyDirectory(out var path))
+        {
+            var dbPath = Path.Combine(path, "encrypted-legacy-aqn.db");
+
+            using (SQLiteConnection raw = new(new(dbPath, true, key: "test123")))
+            {
+                raw.Execute(
+                    "CREATE TABLE CacheElement (Key varchar PRIMARY KEY, TypeName varchar, Value blob, Expiration bigint, CreatedAt bigint)");
+                raw.Execute(
+                    "INSERT INTO CacheElement (Key, TypeName, Value, Expiration, CreatedAt) VALUES (?, ?, ?, ?, ?)",
+                    "aqnKey",
+                    typeof(string).AssemblyQualifiedName,
+                    new byte[] { 8, 8, 8, 8 },
+                    0L,
+                    DateTime.UtcNow.Ticks);
+            }
+
+            await using EncryptedSqlite3.SqliteAkavacheConnection connection = new(
+                new(dbPath, true, key: "test123"));
+
+            var result = await connection.TryReadLegacyV10ValueAsync("aqnKey", DateTimeOffset.UtcNow, typeof(string));
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!).IsEquivalentTo(new byte[] { 8, 8, 8, 8 });
+        }
+    }
+
+    /// <summary>
     /// Verifies the encrypted compilation of <c>SqliteAkavacheConnection</c>'s read-only
     /// open-flags constructor opens an existing SQLCipher database.
     /// </summary>

--- a/src/tests/Akavache.Tests/UniversalSerializerTests.cs
+++ b/src/tests/Akavache.Tests/UniversalSerializerTests.cs
@@ -2629,6 +2629,79 @@ public class UniversalSerializerTests
     }
 
     /// <summary>
+    /// Verifies the BSON-serializer probe classifies concrete serializer types correctly —
+    /// <see cref="SystemJsonBsonSerializer"/> and <see cref="NewtonsoftBsonSerializer"/> are BSON,
+    /// <see cref="SystemJsonSerializer"/> and <see cref="NewtonsoftSerializer"/> are not.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task IsBsonSerializerShouldClassifyConcreteSerializers()
+    {
+        UniversalSerializer.ResetCaches();
+
+        await Assert.That(UniversalSerializer.IsBsonSerializer(new SystemJsonBsonSerializer())).IsTrue();
+        await Assert.That(UniversalSerializer.IsBsonSerializer(new NewtonsoftBsonSerializer())).IsTrue();
+        await Assert.That(UniversalSerializer.IsBsonSerializer(new SystemJsonSerializer())).IsFalse();
+        await Assert.That(UniversalSerializer.IsBsonSerializer(new NewtonsoftSerializer())).IsFalse();
+    }
+
+    /// <summary>
+    /// Verifies the BSON probe returns the same answer on repeat invocations for a given type —
+    /// the second call goes through the cache (different code path from the first).
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task IsBsonSerializerShouldCachePerType()
+    {
+        UniversalSerializer.ResetCaches();
+        SystemJsonBsonSerializer bson = new();
+
+        var first = UniversalSerializer.IsBsonSerializer(bson);
+        var second = UniversalSerializer.IsBsonSerializer(bson);
+        var third = UniversalSerializer.IsBsonSerializer(new SystemJsonBsonSerializer());
+
+        await Assert.That(first).IsTrue();
+        await Assert.That(second).IsTrue();
+        await Assert.That(third).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies the plain-Newtonsoft probe returns true for <see cref="NewtonsoftSerializer"/>
+    /// and false for the BSON variant and System.Text.Json serializers (the "Newtonsoft &amp;&amp;
+    /// !Bson" conjunction).
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task IsPlainNewtonsoftSerializerShouldRequireBothConditions()
+    {
+        UniversalSerializer.ResetCaches();
+
+        await Assert.That(UniversalSerializer.IsPlainNewtonsoftSerializer(new NewtonsoftSerializer())).IsTrue();
+        await Assert.That(UniversalSerializer.IsPlainNewtonsoftSerializer(new NewtonsoftBsonSerializer())).IsFalse();
+        await Assert.That(UniversalSerializer.IsPlainNewtonsoftSerializer(new SystemJsonSerializer())).IsFalse();
+        await Assert.That(UniversalSerializer.IsPlainNewtonsoftSerializer(new SystemJsonBsonSerializer())).IsFalse();
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UniversalSerializer.ResetCaches"/> clears both the BSON and the
+    /// plain-Newtonsoft caches — a subsequent probe re-runs the classification logic.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Test]
+    public async Task ResetCachesShouldClearSerializerKindCaches()
+    {
+        UniversalSerializer.IsBsonSerializer(new SystemJsonBsonSerializer());
+        UniversalSerializer.IsPlainNewtonsoftSerializer(new NewtonsoftSerializer());
+
+        UniversalSerializer.ResetCaches();
+
+        // After reset the next probe should still produce a correct answer — this validates the
+        // classifier doesn't hand back a stale or corrupted result after the caches were cleared.
+        await Assert.That(UniversalSerializer.IsBsonSerializer(new SystemJsonBsonSerializer())).IsTrue();
+        await Assert.That(UniversalSerializer.IsPlainNewtonsoftSerializer(new NewtonsoftSerializer())).IsTrue();
+    }
+
+    /// <summary>
     /// Reset registry between tests so registered serializers don't bleed between tests.
     /// </summary>
     private static void ResetRegistry() => UniversalSerializer.ResetCaches();


### PR DESCRIPTION
## Summary

This PR is a focused allocation-reduction and CPU-reduction pass across the hot paths most Akavache users actually hit every day: cache reads/writes, bulk insert/invalidate, serialization, and the in-memory type-scoped index. Nothing changes in the public API — every optimisation is either internal, additive, or behind a `#if NET…` guard for newer targets with a preserved fallback for `net462` / `netstandard2.0`.

The net effect for consumers: **less GC pressure, fewer per-call delegate allocations, tighter SQLite bulk paths, and faster in-memory cache invalidation under high type-count workloads** — with zero breaking changes and the full test suite (3,894 tests) green on net8 and net9.

---

## Why this matters for you

Akavache is typically used as a read-heavy, write-often key/value store sitting on an app's hot path — settings, HTTP response caching, image caching, offline data. The cost of a single cache hit is easy to ignore, but multiply it by every render or navigation and a handful of per-call allocations becomes a real GC pause, especially on mobile. This pass chips away at those allocations in concrete, measurable places.

### Fewer short-lived objects on every cache call

- **Cached `Observable<Unit>` success signal.** `Rx.NET`'s `Observable.Return(Unit.Default)` allocates a new `ScalarObservable<Unit>` on every call. Methods like `Flush`, `Invalidate`, and successful-write paths return that value constantly. A single internal `CachedObservables.UnitDefault` singleton now serves every one of those sites — roughly 15 call sites across the library, each previously producing a fresh observable per invocation. Paired with a new `.SelectUnit()` extension that centralises the `.Select(_ => Unit.Default)` pattern.
- **`static` lambdas everywhere they belong.** Non-capturing Rx operator lambdas (`.Select(x => x)`, `.Where(x => x.Id is not null)`, `.SelectMany(static x => x)`, etc.) across `SqliteBlobCache`, `InMemoryBlobCacheBase`, `HttpService`, `SerializerExtensions`, `RequestCache`, `BitmapImageExtensions`, `ImageCacheExtensions` and `V10MigrationService` are now marked `static`, so the compiler caches the delegate instance instead of allocating one per subscription.
- **Pre-sized mutable collections.** `List<string>` / `List<KeyValuePair<…>>` instances in bulk paths now use `[.. source]` spread syntax or explicit `new(capacity)` where the upper bound is known from an `ICollection<T>.Count`, avoiding the default-capacity-then-regrow allocation pattern.
- **Ordinal comparers on string-keyed collections.** `InMemoryBlobCacheBase._cache`, the per-type `HashSet<string>` buckets, and `RequestCache._inflightRequests` all use `StringComparer.Ordinal` explicitly. Cache keys are opaque identifiers, not user-facing text — ordinal comparison is both semantically correct and materially faster than the default culture-sensitive comparer, particularly on `net462`.

### Faster SQLite bulk paths

- **Bulk insert no longer calls `DateTime.Now` per entry.** `SqliteBlobCache.Insert(IEnumerable<KVP>, ...)` used to read the wall clock and reflect `type.FullName` inside the per-entry `.Select(...)` projection. Both are hoisted out of the loop so one batch = one wall-clock read.
- **Empty-input early exit.** Calling `Insert` or `Invalidate` with an empty `IEnumerable` no longer schedules an `Observable.Start`, acquires the lock, or allocates a work item — the method short-circuits to the cached `Unit` observable.
- **`GetCreatedAt(key)` / `GetCreatedAt(key, type)` folded into a single async projection.** The previous `SelectMany → SelectMany → Where → Select → DefaultIfEmpty` chain is now one async `SelectMany` that always emits exactly one value (the timestamp or `null`). Same semantics, four fewer Rx operators per call. The defensive null-`Id` filter is preserved inline, verified against the existing `PostQueryDefensiveFilters` test.
- **Legacy V10 fallback reads drop the tuple-list staging buffer.** `SqliteAkavacheConnection.TryReadLegacyV10ValueAsync` used to materialise a `new List<(string Sql, object[] Args)>(3)` and `foreach` over it. It now executes the three query forms inline via a small private helper — same cold-path behaviour, no transient list or tuple allocations.

### O(1) type-index cleanup in `InMemoryBlobCacheBase`

The in-memory cache previously pruned the type index on every invalidation or expiration by **scanning every registered `Type`'s `HashSet<string>`** to remove the key. That's O(T) per key and O(K·T) per bulk invalidation or vacuum — fine for a few types, painful for apps that register hundreds.

A reverse `Dictionary<string, Type>` map (`_keyToType`) is now maintained alongside the per-type index. Insert paths that target a specific type populate it, and if a key is reassigned to a different type the old bucket is evicted first to preserve the invariant. `Invalidate` and `VacuumExpiredEntriesFast` use this to jump directly to the right bucket in O(1) instead of scanning.

### Serializer allocation & CPU reductions

- **Byte-level JSON/BSON probe.** `NewtonsoftSerializer` and `SystemJsonBsonSerializer` used to decode the entire payload into a `string` via `Encoding.UTF8.GetString(data)`, call `.TrimStart()` twice, then `StartsWith("{")` / `StartsWith("[")`. They now go through a shared `BinaryHelpers.StartsWithJsonOpener(byte[])` helper that walks the bytes directly. On `net5+` it uses `MemoryExtensions.TrimStart(ReadOnlySpan<byte>, ReadOnlySpan<byte>)` with a `" \t\n\r"u8` literal, which the JIT can vectorise. `net462` falls back to a tight scalar loop. No string allocation on the probe path at all.
- **`UniversalSerializer` caches serializer-kind flags per `Type`.** `IsBsonSerializer` / `IsPlainNewtonsoftSerializer` previously ran `GetType().Name.Contains(...)` on every call. They now cache the boolean result in a `ConcurrentDictionary<Type, bool>` so hot paths touch the name string once per closed type and then hit the cache forever after.
- **`KeyMetadata<T>` static generic cache.** `UniversalSerializer.FindKeyCandidates<T>` used to walk `typeof(T).FullName`, `.Name`, and `typeof(T).Assembly.GetName().Name` on every cache miss to build the prefix forms. Those three strings are now materialised exactly once per closed generic instantiation via a `static readonly` field on `KeyMetadata<T>`.
- **`MemoryStream` read paths use `writable: false`.** Reading a known `byte[]` via `new MemoryStream(bytes)` used to copy the buffer internally. The read paths in `NewtonsoftSerializer`, `SystemJsonBsonSerializer`, `BitmapImageExtensions` and `ImageCacheExtensions` now pass `writable: false` so the underlying array is used directly.
- **`MemoryStream` write paths are pre-sized.** BSON write paths pre-size to 256 bytes; the `BitmapImageExtensions.ImageToBytes` PNG encode path pre-sizes to 16 KB, dodging the usual doubling regrowths for typical payloads.
- **Newtonsoft fallback probe uses a span trim.** `NewtonsoftSerializer.TryDeserializeFromOtherFormats` now checks the first non-whitespace character via `jsonString.AsSpan().TrimStart()` before any further work, and in most cases short-circuits to the `BinaryHelpers` byte probe before the `Encoding.UTF8.GetString` is ever called.

### Async & `ConfigureAwait` hygiene

- **Pass-through `async`/`await` state machines removed.** `InMemoryBlobCacheBase.DisposeAsync` and the inner `AkavacheBuilder` wrapper's `DisposeAsync` no longer compile into an async state machine — they return the underlying `ValueTask` directly.
- **`ConfigureAwait(false)` sweep.** Task-returning awaits in `BitmapImageExtensions`, `ImageCacheExtensions` and `CacheDatabase`'s shutdown aggregator now pass `false` so the library never captures a synchronization context. (Observable awaits aren't eligible without a larger refactor and are documented as such internally.)

### Ergonomic bits that rode along

- **`CacheEntry` parameterised constructor.** Alongside the sqlite-net-mandated parameterless constructor, there's now a full `CacheEntry(string? id, string? typeName, byte[]? value, DateTimeOffset createdAt, DateTimeOffset? expiresAt)` ctor. On older runtimes (notably `net462`) the JIT tends to produce tighter codegen for a single ctor + field writes than for a `new() { … }` initializer that expands to parameterless ctor + property setters. Insert paths in both `InMemoryBlobCacheBase` and `SqliteBlobCache` use it.
- **`SplitFullPath` is now a `yield return` iterator.** The historical `List<string>` + `Reverse()` pattern is replaced with a depth precount and an array-backed root-down iterator. `CreateRecursive` consumers never see a materialised intermediate list.

---

## Compatibility

- **Public API:** unchanged. No signatures modified, no types removed, no default behaviours flipped.
- **Target frameworks:** all optimisations are either universally applicable or guarded by `#if NET5_0_OR_GREATER` / `#if NET9_0_OR_GREATER` with a preserved `net462` / `netstandard2.0` fallback. `net462` consumers still get the scalar code paths and nothing regresses.
- **SQLite schema:** untouched. `CacheEntry` still matches the existing table definition; the new constructor is additive.
- **Observable semantics:** unchanged. The `Unit` singleton, the `GetCreatedAt` fold, and the defensive null-`Id` filters all produce the same emissions the existing test suite expects.

---

## Maintainer notes

### Test coverage added

A few helpers were promoted from `private` to `internal static` so they can be driven from unit tests without going through the full observable pipeline:

- `InMemoryBlobCacheBase.VacuumExpiredEntriesFast(cache, typeIndex, keyToType, now)` — 3 tests
- `InMemoryBlobCacheBase.RemoveKeyFromTypeIndexFast(typeIndex, keyToType, key)` — 3 tests
- `CacheEntry.ValueEquals(byte[]?, byte[]?)` — 6 tests (same ref, both null, one null, distinct equal, equal length differing content, different length, two empty)
- `CacheEntry` parameterised ctor — 2 tests
- `UniversalSerializer.IsBsonSerializer` / `IsPlainNewtonsoftSerializer` / `ResetCaches` — 4 tests

### Verification

- `dotnet build src/Akavache.slnx` — 0 warnings, 0 errors, all target frameworks.
- `dotnet test --project tests/Akavache.Tests/Akavache.Tests.csproj -- --coverage --coverage-output-format cobertura` — **3,894 / 3,894 passing** on net8 and net9.
- Behavioural regressions were caught and reverted during the sweep — notably an aggressive "redundant `.Where(x => x.Id is not null)`" removal that broke the `EncryptedPostQueryDefensiveFiltersShouldSkipNullIdEntries` test, reminding us the Rx-level filter is the only guard when a backend has `BypassPredicate = true`. That change was reverted; only the folded `GetCreatedAt` shape (with the defensive check preserved inline) made it into the final commit.

## Test plan

- [x] CI: `dotnet test --project tests/Akavache.Tests/Akavache.Tests.csproj` green on all TFMs
- [x] CI: `dotnet test --project tests/Akavache.Settings.Tests/Akavache.Settings.Tests.csproj` green on all TFMs
- [ ] Optional: run the existing benchmark projects under `src/benchmarks/` before and after this branch with `[MemoryDiagnoser]` to confirm the allocation reductions on the bulk-insert and in-memory invalidation paths