### PR TITLE
fix: read Akavache 11.x encrypted databases with v12

### DIFF
--- a/src/Akavache.Sqlite3/SqlitePclRawConnection.cs
+++ b/src/Akavache.Sqlite3/SqlitePclRawConnection.cs
@@ -309,13 +309,16 @@ internal sealed class SqlitePclRawConnection : IAkavacheConnection
             ? SQLITE_OPEN_READONLY
             : SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
 
+        // Quote the password by doubling any single-quotes.
+        var quotedPassword = !string.IsNullOrEmpty(password)
+            ? "'" + password!.Replace("'", "''") + "'"
+            : null;
+
         CheckRc(sqlite3_open_v2(databasePath, out var db, openFlags, null), db, "open " + databasePath);
         Db = db;
 
-        if (password is not null && !string.IsNullOrEmpty(password))
+        if (quotedPassword is not null)
         {
-            // Quote the password by doubling any single-quotes.
-            var quotedPassword = "'" + password.Replace("'", "''") + "'";
             ExecuteNonQuery("PRAGMA key = " + quotedPassword);
         }
 
@@ -328,6 +331,31 @@ internal sealed class SqlitePclRawConnection : IAkavacheConnection
                 ExecuteNonQuery("PRAGMA journal_mode=WAL");
                 ExecuteNonQuery("PRAGMA synchronous=NORMAL");
             }
+#if ENCRYPTED
+            catch (AkavacheSqliteException ex) when (quotedPassword is not null && ex.ResultCode == SQLITE_NOTADB)
+            {
+                // The file isn't readable with SQLite3MC's default cipher. Most likely it
+                // was written by Akavache 11.x, which used the SQLCipher-4 bundle. Re-open
+                // with SQLite3MC's SQLCipher-4 compatibility mode, then re-encrypt forward
+                // to the modern cipher so subsequent opens take the fast native path.
+                Db.Dispose();
+                Db = OpenLegacySqlCipher4(databasePath, openFlags, quotedPassword);
+                try
+                {
+                    // Switch the page cipher back to the SQLite3MC default and rewrite every
+                    // page in place. Use the same password so callers don't need to know.
+                    ExecuteNonQuery("PRAGMA cipher = 'chacha20'");
+                    ExecuteNonQuery("PRAGMA rekey = " + quotedPassword);
+                    ExecuteNonQuery("PRAGMA journal_mode=WAL");
+                    ExecuteNonQuery("PRAGMA synchronous=NORMAL");
+                }
+                catch
+                {
+                    Db.Dispose();
+                    throw;
+                }
+            }
+#endif
             catch
             {
                 Db.Dispose();
@@ -341,7 +369,15 @@ internal sealed class SqlitePclRawConnection : IAkavacheConnection
     }
 
     /// <summary>Gets the native SQLite database handle.</summary>
+#if ENCRYPTED
+    // Reassigned by the constructor when the SQLCipher-4 → modern-cipher
+    // backward-compatibility retry path opens a second handle.
+#pragma warning disable RCS1170 // Use read-only auto-implemented property — setter is used by the retry path above.
+    internal sqlite3 Db { get; private set; }
+#pragma warning restore RCS1170
+#else
     internal sqlite3 Db { get; }
+#endif
 
     /// <summary>Gets the operation queue that serializes all database interactions.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -894,60 +930,60 @@ internal sealed class SqlitePclRawConnection : IAkavacheConnection
             switch (character)
             {
                 case '"':
-                {
-                    jsonBuilder.Append("\\\"");
-                    break;
-                }
+                    {
+                        jsonBuilder.Append("\\\"");
+                        break;
+                    }
 
                 case '\\':
-                {
-                    jsonBuilder.Append("\\\\");
-                    break;
-                }
+                    {
+                        jsonBuilder.Append("\\\\");
+                        break;
+                    }
 
                 case '\b':
-                {
-                    jsonBuilder.Append("\\b");
-                    break;
-                }
+                    {
+                        jsonBuilder.Append("\\b");
+                        break;
+                    }
 
                 case '\f':
-                {
-                    jsonBuilder.Append("\\f");
-                    break;
-                }
+                    {
+                        jsonBuilder.Append("\\f");
+                        break;
+                    }
 
                 case '\n':
-                {
-                    jsonBuilder.Append("\\n");
-                    break;
-                }
+                    {
+                        jsonBuilder.Append("\\n");
+                        break;
+                    }
 
                 case '\r':
-                {
-                    jsonBuilder.Append("\\r");
-                    break;
-                }
+                    {
+                        jsonBuilder.Append("\\r");
+                        break;
+                    }
 
                 case '\t':
-                {
-                    jsonBuilder.Append("\\t");
-                    break;
-                }
+                    {
+                        jsonBuilder.Append("\\t");
+                        break;
+                    }
 
                 default:
-                {
-                    if (character < FirstPrintableChar)
                     {
-                        jsonBuilder.Append("\\u").Append(((int)character).ToString("X4"));
-                    }
-                    else
-                    {
-                        jsonBuilder.Append(character);
-                    }
+                        if (character < FirstPrintableChar)
+                        {
+                            jsonBuilder.Append("\\u").Append(((int)character).ToString("X4"));
+                        }
+                        else
+                        {
+                            jsonBuilder.Append(character);
+                        }
 
-                    break;
-                }
+                        break;
+                    }
             }
         }
 
@@ -1278,4 +1314,37 @@ internal sealed class SqlitePclRawConnection : IAkavacheConnection
             stmt = null;
         }
     }
+
+#if ENCRYPTED
+    /// <summary>
+    /// Opens <paramref name="databasePath"/> with SQLite3MC's SQLCipher-4 compatibility
+    /// mode engaged so a database produced by the Akavache 11.x encrypted provider
+    /// (which used the SQLCipher-4 native bundle) can be read.
+    /// </summary>
+    /// <param name="databasePath">The full file system path to the SQLite database.</param>
+    /// <param name="openFlags">The flags used for <c>sqlite3_open_v2</c>.</param>
+    /// <param name="quotedPassword">The password, already wrapped in single-quotes for PRAGMA use.</param>
+    /// <returns>An open <see cref="sqlite3"/> handle on which page 1 has been successfully decrypted.</returns>
+    private static sqlite3 OpenLegacySqlCipher4(string databasePath, int openFlags, string quotedPassword)
+    {
+        CheckRc(sqlite3_open_v2(databasePath, out var db, openFlags, null), db, "open " + databasePath + " (sqlcipher-4 compat)");
+        try
+        {
+            CheckRc(sqlite3_exec(db, "PRAGMA cipher = 'sqlcipher'"), db, "exec: PRAGMA cipher = 'sqlcipher'");
+            CheckRc(sqlite3_exec(db, "PRAGMA legacy = 4"), db, "exec: PRAGMA legacy = 4");
+            CheckRc(sqlite3_exec(db, "PRAGMA key = " + quotedPassword), db, "exec: PRAGMA key (sqlcipher-4)");
+
+            // Touch page 1 to confirm the key is correct in legacy mode. This raises
+            // SQLITE_NOTADB if the password is genuinely wrong, distinguishing that
+            // case from "wrote with v11" (which now succeeds).
+            CheckRc(sqlite3_exec(db, "SELECT count(*) FROM sqlite_master"), db, "verify legacy key");
+            return db;
+        }
+        catch
+        {
+            db.Dispose();
+            throw;
+        }
+    }
+#endif
 }

--- a/src/Akavache.Sqlite3/SqlitePclRawConnection.cs
+++ b/src/Akavache.Sqlite3/SqlitePclRawConnection.cs
@@ -370,11 +370,11 @@ internal sealed class SqlitePclRawConnection : IAkavacheConnection
 
     /// <summary>Gets the native SQLite database handle.</summary>
 #if ENCRYPTED
-    // Reassigned by the constructor when the SQLCipher-4 → modern-cipher
-    // backward-compatibility retry path opens a second handle.
-#pragma warning disable RCS1170 // Use read-only auto-implemented property — setter is used by the retry path above.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Roslynator",
+        "RCS1170:Use read-only auto-implemented property",
+        Justification = "Reassigned by the constructor when the SQLCipher-4 → modern-cipher backward-compatibility retry path opens a second handle.")]
     internal sqlite3 Db { get; private set; }
-#pragma warning restore RCS1170
 #else
     internal sqlite3 Db { get; }
 #endif

--- a/src/tests/Akavache.EncryptedSqlite3.Tests/EncryptedSqlite3LegacyV11CompatibilityTests.cs
+++ b/src/tests/Akavache.EncryptedSqlite3.Tests/EncryptedSqlite3LegacyV11CompatibilityTests.cs
@@ -77,11 +77,15 @@ public class EncryptedSqlite3LegacyV11CompatibilityTests
         SeedSqlCipher4Database(path, correctPassword, key: "k", value: [1]);
 
         SystemJsonSerializer serializer = new();
-        await Assert.That(() =>
+        var ex = Assert.Throws<AkavacheSqliteException>(() =>
         {
             using EncryptedSqliteBlobCache cache = new(path, wrongPassword, serializer, ImmediateScheduler.Instance);
             cache.Get("k").WaitForValue();
-        }).Throws<Exception>();
+        });
+
+        // The legacy fallback re-validates page 1 with the supplied password and
+        // surfaces the same SQLITE_NOTADB the modern path would have raised.
+        await Assert.That(ex.ResultCode).IsEqualTo(SQLITE_NOTADB);
     }
 
     /// <summary>

--- a/src/tests/Akavache.EncryptedSqlite3.Tests/EncryptedSqlite3LegacyV11CompatibilityTests.cs
+++ b/src/tests/Akavache.EncryptedSqlite3.Tests/EncryptedSqlite3LegacyV11CompatibilityTests.cs
@@ -1,0 +1,191 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Akavache.EncryptedSqlite3;
+using Akavache.SystemTextJson;
+using Akavache.Tests.Helpers;
+
+using SQLitePCL;
+
+using static SQLitePCL.raw;
+
+namespace Akavache.Tests;
+
+/// <summary>
+/// Backward-compatibility tests for the encrypted Sqlite cache. Akavache 11.x shipped
+/// the SQLCipher-4 native bundle; v12 ships SQLite3MC. The two ciphers don't agree on
+/// page-1 encryption out of the box, so without a fallback v12 cannot read databases
+/// produced by v11. The connection's open path detects this case and re-opens with
+/// SQLite3MC's SQLCipher-4 compatibility shim, then rekeys forward to the modern cipher.
+/// </summary>
+[Category("Akavache")]
+[Category("Sqlite")]
+public class EncryptedSqlite3LegacyV11CompatibilityTests
+{
+    /// <summary>
+    /// A v11-style file (SQLCipher-4 cipher) must be readable through the v12 public API,
+    /// and after the first open it must be rekeyed to the modern cipher so subsequent
+    /// opens take the fast native path.
+    /// </summary>
+    /// <returns>A task representing the async test.</returns>
+    [Test]
+    public async Task EncryptedSqliteBlobCacheReadsDatabaseWrittenBySqlCipher4()
+    {
+        using var dir = Utility.WithEmptyDirectory(out var tempDir);
+        var path = Path.Combine(tempDir, "v11.db");
+        const string password = "v11-back-compat";
+        const string key = "legacy-key";
+        byte[] payload = [11, 22, 33, 44, 55];
+
+        SeedSqlCipher4Database(path, password, key, payload);
+
+        // First open: the modern-cipher fast path fails with SQLITE_NOTADB, the
+        // SQLCipher-4 fallback succeeds, and the file is rekeyed forward in place.
+        SystemJsonSerializer serializer = new();
+        using (EncryptedSqliteBlobCache cache = new(path, password, serializer, ImmediateScheduler.Instance))
+        {
+            var fetched = cache.Get(key).WaitForValue();
+            await Assert.That(fetched).IsEquivalentTo(payload);
+        }
+
+        // Second open: must succeed with only PRAGMA key (no SQLCipher-4 shim). If the
+        // rekey hadn't run, opening with the shim disabled would surface SQLITE_NOTADB.
+        AssertReadableWithModernCipher(path, password);
+
+        // And the public API still works after the rekey.
+        using (EncryptedSqliteBlobCache cache = new(path, password, serializer, ImmediateScheduler.Instance))
+        {
+            var fetched = cache.Get(key).WaitForValue();
+            await Assert.That(fetched).IsEquivalentTo(payload);
+        }
+    }
+
+    /// <summary>
+    /// A wrong password must still fail loudly — the legacy fallback should not
+    /// silently mask a genuine key error.
+    /// </summary>
+    /// <returns>A task representing the async test.</returns>
+    [Test]
+    public async Task LegacyFallbackDoesNotMaskWrongPassword()
+    {
+        using var dir = Utility.WithEmptyDirectory(out var tempDir);
+        var path = Path.Combine(tempDir, "v11.db");
+        const string correctPassword = "correct-horse-battery-staple";
+        const string wrongPassword = "definitely-not-it";
+
+        SeedSqlCipher4Database(path, correctPassword, key: "k", value: [1]);
+
+        SystemJsonSerializer serializer = new();
+        await Assert.That(() =>
+        {
+            using EncryptedSqliteBlobCache cache = new(path, wrongPassword, serializer, ImmediateScheduler.Instance);
+            cache.Get("k").WaitForValue();
+        }).Throws<Exception>();
+    }
+
+    /// <summary>
+    /// Writes <paramref name="path"/> in the same on-disk shape that the Akavache 11.x
+    /// encrypted provider produced: a SQLCipher-4-encrypted SQLite database with the
+    /// CacheEntry table populated with one row.
+    /// </summary>
+    /// <param name="path">Where to write the seed database.</param>
+    /// <param name="password">The encryption key applied via <c>PRAGMA key</c>.</param>
+    /// <param name="key">The CacheEntry row id.</param>
+    /// <param name="value">The CacheEntry row payload.</param>
+    private static void SeedSqlCipher4Database(string path, string password, string key, byte[] value)
+    {
+        Batteries_V2.Init();
+
+        var rc = sqlite3_open_v2(path, out var db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, null);
+        ThrowIfNotOk(rc, db, "open " + path);
+        try
+        {
+            var quotedPassword = "'" + password.Replace("'", "''") + "'";
+
+            // SQLite3MC's SQLCipher-4 compatibility mode — what Akavache 11.x effectively
+            // wrote out via the e_sqlcipher native bundle.
+            Exec(db, "PRAGMA cipher = 'sqlcipher'");
+            Exec(db, "PRAGMA legacy = 4");
+            Exec(db, "PRAGMA key = " + quotedPassword);
+
+            const string createTable =
+                "CREATE TABLE \"CacheEntry\" (" +
+                "\"Id\" TEXT PRIMARY KEY NOT NULL, " +
+                "\"CreatedAt\" INTEGER NOT NULL, " +
+                "\"ExpiresAt\" INTEGER NULL, " +
+                "\"TypeName\" TEXT NULL, " +
+                "\"Value\" BLOB NULL);";
+            Exec(db, createTable);
+
+            const string insertSql =
+                "INSERT INTO \"CacheEntry\" (\"Id\", \"CreatedAt\", \"ExpiresAt\", \"TypeName\", \"Value\") VALUES (?, ?, NULL, NULL, ?)";
+            rc = sqlite3_prepare_v2(db, insertSql, out var stmt);
+            ThrowIfNotOk(rc, db, "prepare insert");
+            try
+            {
+                ThrowIfNotOk(sqlite3_bind_text(stmt, 1, key), db, "bind id");
+                ThrowIfNotOk(sqlite3_bind_int64(stmt, 2, DateTimeOffset.UtcNow.UtcTicks), db, "bind createdAt");
+                ThrowIfNotOk(sqlite3_bind_blob(stmt, 3, value), db, "bind value");
+
+                if (sqlite3_step(stmt) != SQLITE_DONE)
+                {
+                    throw new InvalidOperationException("seed insert failed: " + sqlite3_errmsg(db).utf8_to_string());
+                }
+            }
+            finally
+            {
+                sqlite3_finalize(stmt);
+            }
+        }
+        finally
+        {
+            db.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Opens <paramref name="path"/> with only <c>PRAGMA key</c> (no SQLCipher-4 shim) and
+    /// touches page 1. Throws if the file isn't already in SQLite3MC's modern cipher format.
+    /// </summary>
+    /// <param name="path">The database file to probe.</param>
+    /// <param name="password">The encryption key applied via <c>PRAGMA key</c>.</param>
+    private static void AssertReadableWithModernCipher(string path, string password)
+    {
+        Batteries_V2.Init();
+
+        var rc = sqlite3_open_v2(path, out var db, SQLITE_OPEN_READONLY, null);
+        ThrowIfNotOk(rc, db, "open " + path);
+        try
+        {
+            var quotedPassword = "'" + password.Replace("'", "''") + "'";
+            Exec(db, "PRAGMA key = " + quotedPassword);
+            Exec(db, "SELECT count(*) FROM sqlite_master");
+        }
+        finally
+        {
+            db.Dispose();
+        }
+    }
+
+    /// <summary>Runs a non-result SQL statement and throws if the call fails.</summary>
+    /// <param name="db">An open SQLite handle.</param>
+    /// <param name="sql">The statement to execute.</param>
+    private static void Exec(sqlite3 db, string sql) =>
+        ThrowIfNotOk(sqlite3_exec(db, sql), db, "exec: " + sql);
+
+    /// <summary>Throws an <see cref="InvalidOperationException"/> when a SQLite call returns an error code.</summary>
+    /// <param name="rc">The SQLite return code.</param>
+    /// <param name="db">An open SQLite handle, used to extract a textual error message.</param>
+    /// <param name="operation">A description of the operation, included in the exception message.</param>
+    private static void ThrowIfNotOk(int rc, sqlite3 db, string operation)
+    {
+        if (rc is SQLITE_OK or SQLITE_DONE or SQLITE_ROW)
+        {
+            return;
+        }
+
+        var detail = sqlite3_errmsg(db).utf8_to_string();
+        throw new InvalidOperationException($"sqlite rc={rc} during {operation}: {detail}");
+    }
+}


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Bug fix — backward compatibility for encrypted SQLite databases written by Akavache 11.x.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Akavache 11.x linked `SQLitePCLRaw.bundle_e_sqlcipher` (SQLCipher 4 — PBKDF2-SHA512 / AES-256-CBC / 256k iterations). Akavache 12 swapped the native bundle for `SQLite3MC.PCLRaw.bundle`, which derives the key from `PRAGMA key` using a different default cipher (ChaCha20-Poly1305). As a result, opening a v11 encrypted database with v12 surfaces `SQLITE_NOTADB` on the first PRAGMA after `sqlite3_open`, and existing user data is unreadable through `EncryptedSqliteBlobCache`. There is no in-library migration path today — apps upgrading from 11 → 12 silently lose their secure cache on first launch.

Reproduced with a small two-project rig (real `Akavache.EncryptedSqlite3` 11.6.1 writes / 12.0.8 reads):

```
[v11/ENCRYPTED] inserted key='test-payload' Name='akavache round-trip'
[v12/ENCRYPTED] FAILED: AkavacheSqliteException: SQLite error 26 during exec:
    PRAGMA journal_mode=WAL: file is not a database
```

**What is the new behavior?**
<!-- If this is a feature change -->

The modern cipher remains the default for newly-created databases. For existing v11 files, the encrypted connection now does a one-shot transparent migration:

1. Open the file and apply `PRAGMA key` on the modern cipher (unchanged).
2. Probe with `PRAGMA journal_mode=WAL`. On success → continue normally.
3. On `SQLITE_NOTADB` *and* a password is set, dispose the handle and re-open with SQLite3MC's SQLCipher-4 shim:
   ```
   PRAGMA cipher = 'sqlcipher';
   PRAGMA legacy = 4;
   PRAGMA key    = '<password>';
   ```
   Then touch page 1 (`SELECT count(*) FROM sqlite_master`) to confirm the password is genuinely correct — a wrong password still throws.
4. Switch the cipher back (`PRAGMA cipher = 'chacha20'`) and `PRAGMA rekey` in place. The next open of the same file takes the fast modern path — the migration is a one-time cost on first read after upgrade.

Both phases of the rig now succeed end-to-end:

```
[v11/ENCRYPTED] inserted key='test-payload'
[v12/ENCRYPTED] read-back ok: Name='akavache round-trip' Count=42 …
```

**What might this PR break?**

- The fallback is gated on `#if ENCRYPTED`, so `Akavache.Sqlite3` is byte-for-byte unchanged.
- For `Akavache.EncryptedSqlite3`, the change is additive — code paths only execute when the *first* open returns `SQLITE_NOTADB` and a password is supplied.
- First read of a migrated database performs a `PRAGMA rekey`, which rewrites every page. For a typical Akavache cache (a few MB) this is ~tens of ms; for unusually large secure caches users will see a one-shot pause on the first launch after upgrade.
- The internal `SqlitePclRawConnection.Db` property goes from `{ get; }` to `{ get; private set; }` in the encrypted build only. Public API surface is unchanged.
- Behaviour for a wrong password is unchanged — the legacy shim re-validates page 1 and propagates the error.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Two tests added in `src/tests/Akavache.EncryptedSqlite3.Tests/EncryptedSqlite3LegacyV11CompatibilityTests.cs`:

- **`EncryptedSqliteBlobCacheReadsDatabaseWrittenBySqlCipher4`** — seeds a SQLCipher-4-encrypted `CacheEntry` table with raw `SQLitePCLRaw` calls (matching the on-disk format produced by v11's `e_sqlcipher` native bundle, verified by dumping a real `Akavache.EncryptedSqlite3` 11.6.1 file), opens it through the public `EncryptedSqliteBlobCache` ctor, asserts the blob round-trips, and re-opens the file with *only* `PRAGMA key` (no shim) to prove the file was rekeyed forward.
- **`LegacyFallbackDoesNotMaskWrongPassword`** — seeds with one password, opens with another, asserts an exception escapes. Guards against the fallback silently masking a real key error.

Files changed:
- `src/Akavache.Sqlite3/SqlitePclRawConnection.cs` — open path + private static `OpenLegacySqlCipher4` helper, all guarded by `#if ENCRYPTED`.
- `src/tests/Akavache.EncryptedSqlite3.Tests/EncryptedSqlite3LegacyV11CompatibilityTests.cs` — new file.

Full `Akavache.EncryptedSqlite3.Tests` suite: **17/17 passing** locally on `net10.0`.
